### PR TITLE
Updating the CircleCI orbs version as a fix for security failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@5.1
+  hmpps: ministryofjustice/hmpps@6.2
 
 parameters:
   alerts-slack-channel:


### PR DESCRIPTION
Updating the CircleCI orbs version as a fix for security failures as recommended by Peter Philips.

example PR - https://github.com/ministryofjustice/hmpps-nomis-prisoner-api/pull/136

## What does this pull request do?

Updates the circleCI orbs version to 6.2

## What is the intent behind these changes?

Fix security issues and have the latest CircleCI orbs version.