### PR TITLE
VB-2444 - add flag to get contacts call to not return addresses if not needed

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/PrisonerContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/PrisonerContactController.kt
@@ -69,7 +69,7 @@ class PrisonerContactController(
     @Parameter(description = "Query by Person Identifier (NOMIS Person ID)", example = "9147510")
     personId: Long?,
     @RequestParam(value = "withAddress", required = false)
-    @Parameter(description = "Whether the contact details should be returned with address", example = "false")
+    @Parameter(description = "by default returns addresses for all contacts, set to false if contact addresses not needed.", example = "false")
     withAddress: Boolean? = true,
   ): List<ContactDto> {
     log.debug("Prisoner: $prisonerId, Type: $contactType, Person: $personId")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/PrisonerContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/PrisonerContactController.kt
@@ -72,7 +72,7 @@ class PrisonerContactController(
     @Parameter(description = "by default returns addresses for all contacts, set to false if contact addresses not needed.", example = "false")
     withAddress: Boolean? = true,
   ): List<ContactDto> {
-    log.debug("Prisoner: $prisonerId, Type: $contactType, Person: $personId")
+    log.debug("Prisoner: $prisonerId, Type: $contactType, Person: $personId, withAddress = $withAddress")
     return orderByLastNameAndThenFirstName(contactService.getContactList(prisonerId, contactType, personId, withAddress))
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/PrisonerContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/PrisonerContactController.kt
@@ -68,9 +68,12 @@ class PrisonerContactController(
     @RequestParam(value = "id", required = false)
     @Parameter(description = "Query by Person Identifier (NOMIS Person ID)", example = "9147510")
     personId: Long?,
+    @RequestParam(value = "withAddress", required = false)
+    @Parameter(description = "Whether the contact details should be returned with address", example = "false")
+    withAddress: Boolean? = true,
   ): List<ContactDto> {
     log.debug("Prisoner: $prisonerId, Type: $contactType, Person: $personId")
-    return orderByLastNameAndThenFirstName(contactService.getContactList(prisonerId, contactType, personId))
+    return orderByLastNameAndThenFirstName(contactService.getContactList(prisonerId, contactType, personId, withAddress))
   }
 
   private fun orderByLastNameAndThenFirstName(contactList: List<ContactDto>): List<ContactDto> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/IntegrationTestBase.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.prisonercontactregistry.integration
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
@@ -22,6 +23,9 @@ abstract class IntegrationTestBase {
 
   @Autowired
   protected lateinit var jwtAuthHelper: JwtAuthHelper
+
+  @Autowired
+  protected lateinit var objectMapper: ObjectMapper
 
   companion object {
     internal val prisonApiMockServer = PrisonApiMockServer()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/PrisonerContactControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/PrisonerContactControllerTest.kt
@@ -1,10 +1,21 @@
 package uk.gov.justice.digital.hmpps.prisonercontactregistry.integration
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.springframework.boot.test.mock.mockito.SpyBean
+import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.client.PrisonApiClient
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.AddressDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.ContactDto
 
 @Suppress("ClassName")
 class PrisonerContactControllerTest : IntegrationTestBase() {
+  @SpyBean
+  private lateinit var prisonApiClient: PrisonApiClient
 
   @Nested
   inner class authentication {
@@ -46,54 +57,67 @@ class PrisonerContactControllerTest : IntegrationTestBase() {
     prisonApiMockServer.stubGetOffenderContactFullContact(prisonerId)
     prisonApiMockServer.stubGetPersonAddressesFullAddress(personId)
 
-    webTestClient.get().uri("/prisoners/$prisonerId/contacts")
+    val returnResult = webTestClient.get().uri("/prisoners/$prisonerId/contacts")
       .headers(setAuthorisation(roles = listOf("ROLE_PRISONER_CONTACT_REGISTRY")))
       .exchange()
       .expectStatus().isOk
       .expectBody()
-      .jsonPath("$.length()").isEqualTo(1)
-      .jsonPath("$[0].personId").isEqualTo("2187521")
-      .jsonPath("$[0].firstName").isEqualTo("Ehicey")
-      .jsonPath("$[0].middleName").isEqualTo("Danger")
-      .jsonPath("$[0].lastName").isEqualTo("Ireron")
-      .jsonPath("$[0].dateOfBirth").isEqualTo("1912-09-13")
-      .jsonPath("$[0].relationshipCode").isEqualTo("PROB")
-      .jsonPath("$[0].relationshipDescription").isEqualTo("Probation Officer")
-      .jsonPath("$[0].contactType").isEqualTo("O")
-      .jsonPath("$[0].contactTypeDescription").isEqualTo("Official")
-      .jsonPath("$[0].approvedVisitor").isEqualTo("false")
-      .jsonPath("$[0].emergencyContact").isEqualTo("false")
-      .jsonPath("$[0].nextOfKin").isEqualTo("false")
-      .jsonPath("$[0].commentText").isEqualTo("Comment Here")
-      .jsonPath("$[0].restrictions.length()").isEqualTo(1)
-      .jsonPath("$[0].restrictions[0].restrictionType").isEqualTo("BAN")
-      .jsonPath("$[0].restrictions[0].restrictionTypeDescription").isEqualTo("Banned")
-      .jsonPath("$[0].restrictions[0].startDate").isEqualTo("2012-09-13")
-      .jsonPath("$[0].restrictions[0].expiryDate").isEqualTo("2014-09-13")
-      .jsonPath("$[0].restrictions[0].globalRestriction").isEqualTo(false)
-      .jsonPath("$[0].restrictions[0].comment").isEqualTo("Comment Here")
-      .jsonPath("$[0].addresses.length()").isEqualTo(1)
-      .jsonPath("$[0].addresses[0].addressType").isEqualTo("BUS")
-      .jsonPath("$[0].addresses[0].flat").isEqualTo("3B")
-      .jsonPath("$[0].addresses[0].premise").isEqualTo("Liverpool Prison")
-      .jsonPath("$[0].addresses[0].street").isEqualTo("Slinn Street")
-      .jsonPath("$[0].addresses[0].locality").isEqualTo("Brincliffe")
-      .jsonPath("$[0].addresses[0].town").isEqualTo("Birmingham")
-      .jsonPath("$[0].addresses[0].postalCode").isEqualTo("D7 5CC")
-      .jsonPath("$[0].addresses[0].county").isEqualTo("West Midlands")
-      .jsonPath("$[0].addresses[0].country").isEqualTo("England")
-      .jsonPath("$[0].addresses[0].primary").isEqualTo(true)
-      .jsonPath("$[0].addresses[0].noFixedAddress").isEqualTo(false)
-      .jsonPath("$[0].addresses[0].startDate").isEqualTo("2012-05-01")
-      .jsonPath("$[0].addresses[0].endDate").isEqualTo("2016-05-01")
-      .jsonPath("$[0].addresses[0].phones.length()").isEqualTo(1)
-      .jsonPath("$[0].addresses[0].phones[0].number").isEqualTo("504 555 24302")
-      .jsonPath("$[0].addresses[0].phones[0].type").isEqualTo("BUS")
-      .jsonPath("$[0].addresses[0].phones[0].ext").isEqualTo("123")
-      .jsonPath("$[0].addresses[0].addressUsages.length()").isEqualTo(1)
-      .jsonPath("$[0].addresses[0].addressUsages[0].addressUsage").isEqualTo("HDC")
-      .jsonPath("$[0].addresses[0].addressUsages[0].addressUsageDescription").isEqualTo("HDC Address")
-      .jsonPath("$[0].addresses[0].addressUsages[0].activeFlag").isEqualTo(true)
+
+    val contacts = getContactResults(returnResult)
+    assertThat(contacts.size).isEqualTo(1)
+    val contact = contacts[0]
+    assertContact(contact)
+    assertThat(contact.addresses.size).isEqualTo(1)
+    val contactAddress = contact.addresses[0]
+    assertContactAddress(contactAddress)
+  }
+
+  @Test
+  fun `when get contacts call made with withAddress as true address details are returned for a visitor`() {
+    val prisonerId = "A1234AA"
+    val personId: Long = 2187521
+
+    prisonApiMockServer.stubGetOffenderContactFullContact(prisonerId)
+    prisonApiMockServer.stubGetPersonAddressesFullAddress(personId)
+
+    val returnResult = webTestClient.get().uri("/prisoners/$prisonerId/contacts?withAddress=true")
+      .headers(setAuthorisation(roles = listOf("ROLE_PRISONER_CONTACT_REGISTRY")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+
+    val contacts = getContactResults(returnResult)
+    assertThat(contacts.size).isEqualTo(1)
+    val contact = contacts[0]
+    assertContact(contact)
+    assertThat(contact.addresses.size).isEqualTo(1)
+    val contactAddress = contact.addresses[0]
+    assertContactAddress(contactAddress)
+
+    verify(prisonApiClient, times(1)).getPersonAddress(any())
+  }
+
+  @Test
+  fun `when get contacts call made with withAddress as true address details are not returned for a visitor`() {
+    val prisonerId = "A1234AA"
+    val personId: Long = 2187521
+
+    prisonApiMockServer.stubGetOffenderContactFullContact(prisonerId)
+    prisonApiMockServer.stubGetPersonAddressesFullAddress(personId)
+
+    val returnResult = webTestClient.get().uri("/prisoners/$prisonerId/contacts?withAddress=false")
+      .headers(setAuthorisation(roles = listOf("ROLE_PRISONER_CONTACT_REGISTRY")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+
+    val contacts = getContactResults(returnResult)
+    assertThat(contacts.size).isEqualTo(1)
+    val contact = contacts[0]
+    assertContact(contact)
+    assertThat(contact.addresses.size).isEqualTo(0)
+
+    verify(prisonApiClient, times(0)).getPersonAddress(any())
   }
 
   @Test
@@ -243,5 +267,56 @@ class PrisonerContactControllerTest : IntegrationTestBase() {
       .headers(setAuthorisation(roles = listOf("ROLE_PRISONER_CONTACT_REGISTRY")))
       .exchange()
       .expectStatus().isBadRequest
+  }
+
+  private fun getContactResults(returnResult: WebTestClient.BodyContentSpec): Array<ContactDto> {
+    return objectMapper.readValue(returnResult.returnResult().responseBody, Array<ContactDto>::class.java)
+  }
+
+  private fun assertContact(contact: ContactDto) {
+    assertThat(contact.personId).isEqualTo(2187521)
+    assertThat(contact.firstName).isEqualTo("Ehicey")
+    assertThat(contact.middleName).isEqualTo("Danger")
+    assertThat(contact.lastName).isEqualTo("Ireron")
+    assertThat(contact.dateOfBirth).isEqualTo("1912-09-13")
+    assertThat(contact.relationshipCode).isEqualTo("PROB")
+    assertThat(contact.relationshipDescription).isEqualTo("Probation Officer")
+    assertThat(contact.contactType).isEqualTo("O")
+    assertThat(contact.contactTypeDescription).isEqualTo("Official")
+    assertThat(contact.approvedVisitor).isFalse
+    assertThat(contact.emergencyContact).isFalse
+    assertThat(contact.nextOfKin).isFalse
+    assertThat(contact.commentText).isEqualTo("Comment Here")
+    assertThat(contact.restrictions.size).isEqualTo(1)
+    assertThat(contact.restrictions[0].restrictionType).isEqualTo("BAN")
+    assertThat(contact.restrictions[0].restrictionTypeDescription).isEqualTo("Banned")
+    assertThat(contact.restrictions[0].startDate).isEqualTo("2012-09-13")
+    assertThat(contact.restrictions[0].expiryDate).isEqualTo("2014-09-13")
+    assertThat(contact.restrictions[0].globalRestriction).isEqualTo(false)
+    assertThat(contact.restrictions[0].comment).isEqualTo("Comment Here")
+  }
+
+  private fun assertContactAddress(contactAddress: AddressDto) {
+    assertThat(contactAddress.addressType).isEqualTo("BUS")
+    assertThat(contactAddress.flat).isEqualTo("3B")
+    assertThat(contactAddress.premise).isEqualTo("Liverpool Prison")
+    assertThat(contactAddress.street).isEqualTo("Slinn Street")
+    assertThat(contactAddress.locality).isEqualTo("Brincliffe")
+    assertThat(contactAddress.town).isEqualTo("Birmingham")
+    assertThat(contactAddress.postalCode).isEqualTo("D7 5CC")
+    assertThat(contactAddress.county).isEqualTo("West Midlands")
+    assertThat(contactAddress.country).isEqualTo("England")
+    assertThat(contactAddress.primary).isEqualTo(true)
+    assertThat(contactAddress.noFixedAddress).isEqualTo(false)
+    assertThat(contactAddress.startDate).isEqualTo("2012-05-01")
+    assertThat(contactAddress.endDate).isEqualTo("2016-05-01")
+    assertThat(contactAddress.phones.size).isEqualTo(1)
+    assertThat(contactAddress.phones[0].number).isEqualTo("504 555 24302")
+    assertThat(contactAddress.phones[0].type).isEqualTo("BUS")
+    assertThat(contactAddress.phones[0].ext).isEqualTo("123")
+    assertThat(contactAddress.addressUsages.size).isEqualTo(1)
+    assertThat(contactAddress.addressUsages[0].addressUsage).isEqualTo("HDC")
+    assertThat(contactAddress.addressUsages[0].addressUsageDescription).isEqualTo("HDC Address")
+    assertThat(contactAddress.addressUsages[0].activeFlag).isEqualTo(true)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/service/PrisonerContactRegistryServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/service/PrisonerContactRegistryServiceTest.kt
@@ -164,6 +164,52 @@ internal class PrisonerContactRegistryServiceTest {
   }
 
   @Test
+  fun `get contact returns addresses when withAddress is true`() {
+    val prisonerId = "A1234AA"
+
+    whenever(
+      apiClient.getOffenderContacts(prisonerId),
+    ).thenReturn(ContactsDto(listOf(offenderContact)))
+    whenever(
+      apiClient.getPersonAddress(any()),
+    ).thenReturn(listOf(personAddress))
+
+    val contacts = contactService.getContactList(prisonerId, withAddress = true)
+
+    assertThat(contacts).isNotNull
+    assertThat(contacts).isNotEmpty
+    assertThat(contacts[0]).isNotNull
+    assertThat(contacts[0].addresses).isNotNull
+    assertThat(contacts[0].addresses).isNotEmpty
+
+    verify(apiClient, times(1)).getOffenderContacts(prisonerId)
+  }
+
+  @Test
+  fun `get contact returns addresses when withAddress is false`() {
+    val prisonerId = "A1234AA"
+    offenderContact.addresses = emptyList()
+
+    whenever(
+      apiClient.getOffenderContacts(prisonerId),
+    ).thenReturn(ContactsDto(listOf(offenderContact)))
+
+    whenever(
+      apiClient.getPersonAddress(any()),
+    ).thenReturn(listOf(personAddress))
+
+    val contacts = contactService.getContactList(prisonerId, withAddress = false)
+
+    assertThat(contacts).isNotNull
+    assertThat(contacts).isNotEmpty
+    assertThat(contacts[0]).isNotNull
+    assertThat(contacts[0].addresses).isEmpty()
+
+    verify(apiClient, times(1)).getOffenderContacts(prisonerId)
+    verify(apiClient, times(0)).getPersonAddress(any())
+  }
+
+  @Test
   fun `Get Contact Returns Contact List with person Not Found`() {
     val prisonerId = "A1234AA"
 


### PR DESCRIPTION
## What does this pull request do?

Allows getting address only if needed.

## What is the intent behind these changes?

Performance improvements around prisoner profile as address is not needed on prisoner profile page.