### PR TITLE
VB-3115 - set productId to DPS035 

### DIFF
--- a/helm_deploy/prisoner-contact-registry/values.yaml
+++ b/helm_deploy/prisoner-contact-registry/values.yaml
@@ -1,7 +1,8 @@
 ---
 generic-service:
   nameOverride: prisoner-contact-registry
-
+  serviceAccountName: visit-someone-in-prison
+  productId: "DPS035"
   replicaCount: 4
 
   image:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -2,14 +2,9 @@
 # Per environment values which override defaults in prisoner-contact-registry/values.yaml
 generic-service:
   replicaCount: 2
-  v1_2_enabled: true
-  v0_47_enabled: false
 
   ingress:
     host: prisoner-contact-registry-dev.prison.service.justice.gov.uk
-    contextColour: green
-    v1_2_enabled: true
-    v0_47_enabled: false
 
   env:
     SPRING_PROFILES_ACTIVE: "stdout"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -3,14 +3,9 @@
 
 generic-service:
   replicaCount: 2
-  v1_2_enabled: true
-  v0_47_enabled: false
 
   ingress:
     host: prisoner-contact-registry-preprod.prison.service.justice.gov.uk
-    contextColour: green
-    v1_2_enabled: true
-    v0_47_enabled: false
 
   env:
     HMPPS_AUTH_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -3,14 +3,9 @@
 
 generic-service:
   replicaCount: 4
-  v1_2_enabled: true
-  v0_47_enabled: false
 
   ingress:
     host: prisoner-contact-registry.prison.service.justice.gov.uk
-    contextColour: green
-    v1_2_enabled: true
-    v0_47_enabled: false
 
   env:
     HMPPS_AUTH_URL: https://sign-in.hmpps.service.justice.gov.uk/auth

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -2,14 +2,9 @@
 # Per environment values which override defaults in prisoner-contact-registry/values.yaml
 generic-service:
   replicaCount: 2
-  v1_2_enabled: true
-  v0_47_enabled: false
 
   ingress:
     host: prisoner-contact-registry-staging.prison.service.justice.gov.uk
-    contextColour: green
-    v1_2_enabled: true
-    v0_47_enabled: false
 
   env:
     SPRING_PROFILES_ACTIVE: "stdout"


### PR DESCRIPTION
VB-3115 -

- set productId to DPS035
- remove contextColour, v1_2_enabled and v0_47_enabled as these are no longer needed.
 

## What does this pull request do?

set productId to DPS035

## What is the intent behind these changes?

VB-3115