### PR TITLE
VB-3801 Do not filter on 'activeOnly'

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/client/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/client/PrisonApiClient.kt
@@ -24,7 +24,7 @@ class PrisonApiClient(
 
   fun getOffenderContacts(offenderNo: String): ContactsDto? {
     return webClient.get()
-      .uri("/api/offenders/$offenderNo/contacts?approvedVisitorsOnly=true&activeOnly=true")
+      .uri("/api/offenders/$offenderNo/contacts?approvedVisitorsOnly=true")
       .retrieve()
       .bodyToMono(contacts)
       .block(apiTimeout)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/mock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/mock/PrisonApiMockServer.kt
@@ -9,7 +9,7 @@ class PrisonApiMockServer : WireMockServer(8092) {
 
   fun stubGetOffenderContactsEmpty(offenderNo: String) {
     stubFor(
-      get("/api/offenders/$offenderNo/contacts?approvedVisitorsOnly=true&activeOnly=true")
+      get("/api/offenders/$offenderNo/contacts?approvedVisitorsOnly=true")
         .willReturn(
           aResponse()
             .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
@@ -27,7 +27,7 @@ class PrisonApiMockServer : WireMockServer(8092) {
 
   fun stubGetOffenderContactFullContact(offenderNo: String) {
     stubFor(
-      get("/api/offenders/$offenderNo/contacts?approvedVisitorsOnly=true&activeOnly=true")
+      get("/api/offenders/$offenderNo/contacts?approvedVisitorsOnly=true")
         .willReturn(
           aResponse()
             .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
@@ -78,7 +78,7 @@ class PrisonApiMockServer : WireMockServer(8092) {
 
   fun stubGetOffenderContactMinimumContact(offenderNo: String) {
     stubFor(
-      get("/api/offenders/$offenderNo/contacts?approvedVisitorsOnly=true&activeOnly=true")
+      get("/api/offenders/$offenderNo/contacts?approvedVisitorsOnly=true")
         .willReturn(
           aResponse()
             .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
@@ -116,7 +116,7 @@ class PrisonApiMockServer : WireMockServer(8092) {
 
   fun stubGetOffenderContactsForOrderingByNames(offenderNo: String) {
     stubFor(
-      get("/api/offenders/$offenderNo/contacts?approvedVisitorsOnly=true&activeOnly=true")
+      get("/api/offenders/$offenderNo/contacts?approvedVisitorsOnly=true")
         .willReturn(
           aResponse()
             .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
@@ -205,7 +205,7 @@ class PrisonApiMockServer : WireMockServer(8092) {
 
   fun stubGetOffenderNotFound(offenderNo: String) {
     stubFor(
-      get("/api/offenders/$offenderNo/contacts?approvedVisitorsOnly=true&activeOnly=true")
+      get("/api/offenders/$offenderNo/contacts?approvedVisitorsOnly=true")
         .willReturn(
           aResponse()
             .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)


### PR DESCRIPTION
Prison API docs state that "visitors can be inactive contacts" - https://prison-api-dev.prison.service.justice.gov.uk/swagger-ui/index.html#/offenders/getOffenderContacts

## What does this pull request do?

Keep the new filter for `approvedVisitorsOnly` but don't use the `activeOnly` filter because it is stopping valid visitors from showing.

## What is the intent behind these changes?

Show all visitors that are approved for visits.