### PR TITLE
Introduce a test coverage plugin to allow developers to track their testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ Run:
 ./gradlew test 
 ```
 
+Testing coverage report
+
+Run:
+```
+./gradlew koverHtmlReport
+```
+Then view output file for coverage report.
+
+
 ## Running
 
 This service connects to a development environment for downstream APIs. 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
   id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.15.6"
   kotlin("plugin.spring") version "1.9.23"
   id("org.jetbrains.kotlin.plugin.noarg") version "1.9.23"
+  id("org.jetbrains.kotlinx.kover") version "0.7.6"
 }
 
 configurations {


### PR DESCRIPTION
## What does this pull request do?

Introduce a test coverage plugin to allow developers to track their testing

Documentation:
https://kotlin.github.io/kotlinx-kover/gradle-plugin/

Example command to generate a HTML report locally:
./gradlew koverHtmlReport

Example report output:
<img width="1728" alt="image" src="https://github.com/ministryofjustice/prisoner-contact-registry/assets/168211160/0a6aec47-be25-412c-9c5e-6dfc14c829ac">

Example class coverage:
<img width="1718" alt="image" src="https://github.com/ministryofjustice/prisoner-contact-registry/assets/168211160/3b3f2394-132c-4361-98d9-1135f401f4e8">

