### PR TITLE
Connect to upstream services using client ID instead of passing the calling application's client ID.

### DIFF
--- a/helm_deploy/prisoner-contact-registry/values.yaml
+++ b/helm_deploy/prisoner-contact-registry/values.yaml
@@ -30,6 +30,8 @@ generic-service:
   namespace_secrets:
     prisoner-contact-registry:
       APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
+      SYSTEM_CLIENT_ID: "SYSTEM_CLIENT_ID"
+      SYSTEM_CLIENT_SECRET: "SYSTEM_CLIENT_SECRET"
 
   allowlist:
     groups:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/IntegrationTestBase.kt
@@ -5,6 +5,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
@@ -17,11 +18,13 @@ import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.ContactsDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.RestrictionDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.enum.RestrictionType
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.helper.JwtAuthHelper
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.integration.mock.HmppsAuthExtension
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.integration.mock.PrisonApiMockServer
 import java.time.LocalDate
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("test")
+@ExtendWith(HmppsAuthExtension::class)
 abstract class IntegrationTestBase {
 
   @Suppress("SpringJavaInjectionPointsAutowiringInspection")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/mock/HmppsAuthMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/mock/HmppsAuthMockServer.kt
@@ -1,0 +1,83 @@
+package uk.gov.justice.digital.hmpps.prisonercontactregistry.integration.mock
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.http.HttpHeader
+import com.github.tomakehurst.wiremock.http.HttpHeaders
+import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.integration.mock.MockUtils.Companion.createJsonResponseBuilder
+
+class HmppsAuthExtension : BeforeAllCallback, AfterAllCallback, BeforeEachCallback {
+
+  companion object {
+    @JvmField
+    val hmppsAuthApi = HmppsAuthMockServer()
+  }
+
+  override fun beforeAll(context: ExtensionContext) {
+    hmppsAuthApi.start()
+    hmppsAuthApi.stubGrantToken()
+    hmppsAuthApi.stubGetUserDetails("created-user")
+    hmppsAuthApi.stubGetUserDetails("updated-user")
+    hmppsAuthApi.stubGetUserDetails("cancelled-user")
+  }
+
+  override fun beforeEach(context: ExtensionContext) {
+    hmppsAuthApi.resetRequests()
+  }
+
+  override fun afterAll(context: ExtensionContext) {
+    hmppsAuthApi.stop()
+  }
+}
+
+class HmppsAuthMockServer : WireMockServer(WIREMOCK_PORT) {
+  companion object {
+    private const val WIREMOCK_PORT = 8090
+  }
+
+  fun stubGrantToken() {
+    stubFor(
+      post(urlEqualTo("/auth/oauth/token"))
+        .willReturn(
+          aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withBody(
+              """
+              {
+                "token_type": "bearer",
+                "access_token": "atoken"
+              }
+              """.trimIndent(),
+            ),
+        ),
+    )
+  }
+
+  fun stubGetUserDetails(userId: String, fullName: String? = "$userId-name") {
+    val responseBuilder = createJsonResponseBuilder()
+
+    stubFor(
+      get("/auth/api/user/$userId")
+        .willReturn(
+          responseBuilder
+            .withStatus(HttpStatus.OK.value())
+            .withBody(
+              """
+              {
+                 "username": "$userId",
+                 "name": "$fullName"
+                }
+              """.trimIndent(),
+            ),
+        ),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/mock/MockUtils.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/mock/MockUtils.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.prisonercontactregistry.integration.mock
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
+import com.github.tomakehurst.wiremock.client.WireMock
+import org.springframework.http.MediaType
+
+class MockUtils {
+  companion object {
+    fun createJsonResponseBuilder(): ResponseDefinitionBuilder {
+      return WireMock.aResponse().withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+    }
+  }
+}


### PR DESCRIPTION


## What does this pull request do?

Connect to upstream services using client ID instead of passing the calling application's client ID.
## What is the intent behind these changes?

Security improvements and making it consistent with other projects.