### PR TITLE
VB-4000: Bug Fix / Feature: unapproved visitors not showing

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/PrisonerContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/PrisonerContactController.kt
@@ -29,6 +29,7 @@ const val PRISON_GET_SOCIAL_CONTACTS_CONTROLLER_PATH: String = "$PRISON_CONTACTS
 // TODO: This endpoint is deprecated now. Remove in future.
 const val PRISON_GET_APPROVED_SOCIAL_CONTACTS_CONTROLLER_PATH: String = "$PRISON_CONTACTS_CONTROLLER_PATH/approved/social/contacts"
 
+// TODO: These endpoints need updating to be correct structure: "/prisoners/{prisonerId}/contacts/social/approved/..."
 const val PRISON_GET_BANNED_DATE_RANGE_CONTROLLER_PATH: String = "$PRISON_GET_APPROVED_SOCIAL_CONTACTS_CONTROLLER_PATH/restrictions/banned/dateRange"
 const val PRISON_GET_CLOSED_RESTRICTIONS_CONTROLLER_PATH: String = "$PRISON_GET_APPROVED_SOCIAL_CONTACTS_CONTROLLER_PATH/restrictions/closed"
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/PrisonerContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/PrisonerContactController.kt
@@ -26,7 +26,7 @@ const val PRISON_CONTACTS_CONTROLLER_PATH: String = "/prisoners/{prisonerId}"
 const val PRISON_GET_ALL_CONTACTS_CONTROLLER_PATH: String = "$PRISON_CONTACTS_CONTROLLER_PATH/contacts"
 const val PRISON_GET_SOCIAL_CONTACTS_CONTROLLER_PATH: String = "$PRISON_CONTACTS_CONTROLLER_PATH/contacts/social"
 
-// TODO: Restructure URLs to "/contacts/social/approved"
+// TODO: This endpoint is deprecated now. Remove in future.
 const val PRISON_GET_APPROVED_SOCIAL_CONTACTS_CONTROLLER_PATH: String = "$PRISON_CONTACTS_CONTROLLER_PATH/approved/social/contacts"
 
 const val PRISON_GET_BANNED_DATE_RANGE_CONTROLLER_PATH: String = "$PRISON_GET_APPROVED_SOCIAL_CONTACTS_CONTROLLER_PATH/restrictions/banned/dateRange"
@@ -97,9 +97,6 @@ class PrisonerContactController(
       .sortedWith(getDefaultSortOrder())
   }
 
-  // TODO: Combine PRISON_GET_SOCIAL_CONTACTS_CONTROLLER_PATH & PRISON_GET_APPROVED_SOCIAL_CONTACTS_CONTROLLER_PATH
-  //  with new optional parameter "approvedVisitorsOnly" which defaults to true if not passed in. As all logic is shared
-  //  by these endpoints with only 1 flag difference.
   @PreAuthorize("hasRole('PRISONER_CONTACT_REGISTRY')")
   @GetMapping(PRISON_GET_SOCIAL_CONTACTS_CONTROLLER_PATH)
   @Operation(
@@ -148,8 +145,10 @@ class PrisonerContactController(
     @RequestParam(value = "withAddress", required = false)
     @Parameter(description = "by default returns addresses for all contacts, set to false if contact addresses not needed.", example = "false")
     withAddress: Boolean? = true,
+    @Parameter(description = "by default set to true and will return only approved social contacts. If false, returns all social contacts", example = "false")
+    approvedVisitorsOnly: Boolean? = true,
   ): List<ContactDto> {
-    log.debug("getPrisonerSocialContacts called with params : Prisoner: {}, id : {}, hasDateOfBirth = {}, notBannedBeforeDate = {}, withAddress = {}", prisonerId, personId, hasDateOfBirth, notBannedBeforeDate, withAddress)
+    log.debug("getPrisonerSocialContacts called with params : Prisoner: {}, id : {}, hasDateOfBirth = {}, notBannedBeforeDate = {}, withAddress = {}, approvedVisitorsOnly = {}", prisonerId, personId, hasDateOfBirth, notBannedBeforeDate, withAddress, approvedVisitorsOnly)
 
     return contactService.getSocialContactList(
       prisonerId = prisonerId,
@@ -157,10 +156,11 @@ class PrisonerContactController(
       withAddress = withAddress ?: true,
       hasDateOfBirth = hasDateOfBirth,
       notBannedBeforeDate = notBannedBeforeDate,
-      approvedVisitorsOnly = false,
+      approvedVisitorsOnly = approvedVisitorsOnly ?: true,
     ).sortedWith(getDefaultSortOrder())
   }
 
+  @Deprecated("This has been replaced by PRISON_GET_SOCIAL_CONTACTS_CONTROLLER_PATH endpoint")
   @PreAuthorize("hasRole('PRISONER_CONTACT_REGISTRY')")
   @GetMapping(PRISON_GET_APPROVED_SOCIAL_CONTACTS_CONTROLLER_PATH)
   @Operation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/service/PrisonerContactRegistryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/service/PrisonerContactRegistryService.kt
@@ -64,15 +64,16 @@ class PrisonerContactRegistryService(private val prisonApiClient: PrisonApiClien
     return contacts
   }
 
-  fun getApprovedSocialContactList(
+  fun getSocialContactList(
     prisonerId: String,
     personId: Long? = null,
     withAddress: Boolean,
     hasDateOfBirth: Boolean? = null,
     notBannedBeforeDate: LocalDate? = null,
+    approvedVisitorsOnly: Boolean,
   ): List<ContactDto> {
-    log.debug("getApprovedSocialContactList called with parameters : prisonerId - {}, personId - {}, withAddress - {}, hasDateOfBirth - {}, notBannedBeforeDate - {}", prisonerId, personId, withAddress, hasDateOfBirth, notBannedBeforeDate)
-    var contacts = getContactList(prisonerId = prisonerId, contactType = "S", personId = personId, withAddress = withAddress, approvedVisitorsOnly = true)
+    log.debug("getSocialContactList called with parameters : prisonerId - {}, personId - {}, withAddress - {}, hasDateOfBirth - {}, notBannedBeforeDate - {}, approvedVisitsOnly - {}", prisonerId, personId, withAddress, hasDateOfBirth, notBannedBeforeDate, approvedVisitorsOnly)
+    var contacts = getContactList(prisonerId = prisonerId, contactType = "S", personId = personId, withAddress = withAddress, approvedVisitorsOnly = approvedVisitorsOnly)
 
     if (hasDateOfBirth != null && hasDateOfBirth) {
       contacts = contacts.filter { hasContactGotDateOfBirth(it) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/IntegrationTestBase.kt
@@ -99,7 +99,7 @@ abstract class IntegrationTestBase {
     assertThat(actualContact.relationshipDescription).isEqualTo(expectedContact.relationshipDescription)
     assertThat(actualContact.contactType).isEqualTo("S")
     assertThat(actualContact.contactTypeDescription).isEqualTo("Social")
-    assertThat(actualContact.approvedVisitor).isTrue()
+    assertThat(actualContact.approvedVisitor).isEqualTo(expectedContact.approvedVisitor)
     assertThat(actualContact.emergencyContact).isEqualTo(expectedContact.emergencyContact)
     assertThat(actualContact.nextOfKin).isEqualTo(expectedContact.nextOfKin)
     assertThat(actualContact.commentText).isEqualTo(expectedContact.commentText)
@@ -159,6 +159,7 @@ abstract class IntegrationTestBase {
     nextOfKin: Boolean = false,
     personId: Long,
     restrictions: List<RestrictionDto> = emptyList(),
+    approvedVisitor: Boolean = true,
   ): ContactDto {
     return ContactDto(
       lastName = lastName,
@@ -173,7 +174,7 @@ abstract class IntegrationTestBase {
       emergencyContact = emergencyContact,
       nextOfKin = nextOfKin,
       personId = personId,
-      approvedVisitor = true,
+      approvedVisitor = approvedVisitor,
       restrictions = restrictions,
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/PrisonerGetApprovedSocialContactsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/PrisonerGetApprovedSocialContactsTest.kt
@@ -17,7 +17,7 @@ import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.ContactsDto
 import java.time.LocalDate
 
 @Suppress("ClassName")
-class PrisonerGetSocialContactsTest : IntegrationTestBase() {
+class PrisonerGetApprovedSocialContactsTest : IntegrationTestBase() {
   @SpyBean
   private lateinit var prisonApiClientSpy: PrisonApiClient
 
@@ -81,22 +81,14 @@ class PrisonerGetSocialContactsTest : IntegrationTestBase() {
     restrictions = emptyList(),
   )
 
-  private val socialUnapprovedContact = createContact(
-    lastName = "BVisitor",
-    firstName = "Social",
-    dateOfBirth = LocalDate.of(1912, 9, 13),
-    personId = 5L,
-    approvedVisitor = false,
-  )
-
-  fun callGetSocialContacts(
+  fun callGetApprovedSocialContacts(
     prisonerId: String,
     personId: Long? = null,
     hasDateOfBirth: Boolean? = null,
     notBannedBeforeDate: LocalDate? = null,
     withAddress: Boolean? = null,
   ): WebTestClient.ResponseSpec {
-    val uri = "/prisoners/$prisonerId/contacts/social?${getContactsQueryParams(personId, hasDateOfBirth, notBannedBeforeDate, withAddress)}"
+    val uri = "/prisoners/$prisonerId/approved/social/contacts?${getContactsQueryParams(personId, hasDateOfBirth, notBannedBeforeDate, withAddress)}"
     return webTestClient.get().uri(uri)
       .headers(setAuthorisation(roles = listOf("ROLE_PRISONER_CONTACT_REGISTRY")))
       .exchange()
@@ -107,7 +99,7 @@ class PrisonerGetSocialContactsTest : IntegrationTestBase() {
     @Test
     fun `requires authentication`() {
       val prisonerId = "A1234AA"
-      webTestClient.get().uri("/prisoners/$prisonerId/contacts/social")
+      webTestClient.get().uri("/prisoners/$prisonerId/approved/social/contacts")
         .exchange()
         .expectStatus().isUnauthorized
     }
@@ -115,7 +107,7 @@ class PrisonerGetSocialContactsTest : IntegrationTestBase() {
     @Test
     fun `requires correct role`() {
       val prisonerId = "A1234AA"
-      webTestClient.get().uri("/prisoners/$prisonerId/contacts/social")
+      webTestClient.get().uri("/prisoners/$prisonerId/approved/social/contacts")
         .headers(setAuthorisation(roles = listOf("AnyThingWillDo")))
         .exchange()
         .expectStatus().isForbidden
@@ -126,8 +118,8 @@ class PrisonerGetSocialContactsTest : IntegrationTestBase() {
     @Test
     fun `requires correct role PRISONER_CONTACT_REGISTRY`() {
       val prisonerId = "A1234AA"
-      prisonApiMockServer.stubGetOffenderContacts(prisonerId, ContactsDto(emptyList()))
-      webTestClient.get().uri("/prisoners/$prisonerId/contacts/social")
+      prisonApiMockServer.stubGetApprovedOffenderContacts(prisonerId, ContactsDto(emptyList()))
+      webTestClient.get().uri("/prisoners/$prisonerId/approved/social/contacts")
         .headers(setAuthorisation(roles = listOf("ROLE_PRISONER_CONTACT_REGISTRY")))
         .exchange()
         .expectStatus().isOk
@@ -138,12 +130,12 @@ class PrisonerGetSocialContactsTest : IntegrationTestBase() {
   fun `when prisoner has both social and official contacts only social contacts are returned`() {
     val prisonerId = "A1234AA"
 
-    prisonApiMockServer.stubGetOffenderContacts(
+    prisonApiMockServer.stubGetApprovedOffenderContacts(
       prisonerId,
       contacts = ContactsDto(
         listOf(
           socialContactWithExpiredBannedRestriction,
-          socialUnapprovedContact,
+          socialContactWithCurrentBannedRestriction,
           socialContactWithNoDOB,
           officialContact,
         ),
@@ -151,31 +143,31 @@ class PrisonerGetSocialContactsTest : IntegrationTestBase() {
     )
 
     prisonApiMockServer.stubGetPersonAddressesFullAddress(socialContactWithExpiredBannedRestriction.personId!!)
-    prisonApiMockServer.stubGetPersonAddressesFullAddress(socialUnapprovedContact.personId!!)
+    prisonApiMockServer.stubGetPersonAddressesFullAddress(socialContactWithCurrentBannedRestriction.personId!!)
     prisonApiMockServer.stubGetPersonAddressesFullAddress(socialContactWithNoDOB.personId!!)
     prisonApiMockServer.stubGetPersonAddressesFullAddress(officialContact.personId!!)
 
-    val returnResult = callGetSocialContacts(prisonerId)
+    val returnResult = callGetApprovedSocialContacts(prisonerId)
       .expectStatus().isOk
       .expectBody()
 
     val contacts = getContactResults(returnResult)
     assertThat(contacts.size).isEqualTo(3)
     val contact1 = contacts[0]
-    assertContact(contact1, socialContactWithExpiredBannedRestriction)
+    assertContact(contact1, socialContactWithCurrentBannedRestriction)
     assertContactAddress(contact1.addresses[0])
 
     val contact2 = contacts[1]
-    assertContact(contact2, socialUnapprovedContact)
+    assertContact(contact2, socialContactWithExpiredBannedRestriction)
     assertContactAddress(contact2.addresses[0])
 
     val contact3 = contacts[2]
     assertContact(contact3, socialContactWithNoDOB)
     assertContactAddress(contact3.addresses[0])
 
-    verify(prisonApiClientSpy, times(1)).getOffenderContacts(prisonerId, false)
+    verify(prisonApiClientSpy, times(1)).getOffenderContacts(prisonerId, true)
     verify(prisonApiClientSpy, times(1)).getPersonAddress(socialContactWithExpiredBannedRestriction.personId!!)
-    verify(prisonApiClientSpy, times(1)).getPersonAddress(socialUnapprovedContact.personId!!)
+    verify(prisonApiClientSpy, times(1)).getPersonAddress(socialContactWithCurrentBannedRestriction.personId!!)
     verify(prisonApiClientSpy, times(1)).getPersonAddress(socialContactWithNoDOB.personId!!)
   }
 
@@ -183,19 +175,19 @@ class PrisonerGetSocialContactsTest : IntegrationTestBase() {
   fun `when prisoner has official contacts only and no social contacts no contacts are returned`() {
     val prisonerId = "A1234AA"
 
-    prisonApiMockServer.stubGetOffenderContacts(prisonerId, contacts = ContactsDto(listOf(officialContact)))
+    prisonApiMockServer.stubGetApprovedOffenderContacts(prisonerId, contacts = ContactsDto(listOf(officialContact)))
     prisonApiMockServer.stubGetPersonAddressesFullAddress(socialContactWithExpiredBannedRestriction.personId!!)
     prisonApiMockServer.stubGetPersonAddressesFullAddress(socialContactWithCurrentBannedRestriction.personId!!)
     prisonApiMockServer.stubGetPersonAddressesFullAddress(officialContact.personId!!)
 
-    val returnResult = callGetSocialContacts(prisonerId)
+    val returnResult = callGetApprovedSocialContacts(prisonerId)
       .expectStatus().isOk
       .expectBody()
 
     val contacts = getContactResults(returnResult)
     assertThat(contacts).isEmpty()
 
-    verify(prisonApiClientSpy, times(1)).getOffenderContacts(prisonerId, false)
+    verify(prisonApiClientSpy, times(1)).getOffenderContacts(prisonerId, true)
     verify(prisonApiClientSpy, times(0)).getPersonAddress(any())
   }
 
@@ -203,17 +195,17 @@ class PrisonerGetSocialContactsTest : IntegrationTestBase() {
   fun `when person id is passed only one contact is returned`() {
     val prisonerId = "A1234AA"
 
-    prisonApiMockServer.stubGetOffenderContacts(prisonerId, contacts = ContactsDto(listOf(socialUnapprovedContact, socialContactWithExpiredBannedRestriction, socialContactWithCurrentBannedRestriction)))
+    prisonApiMockServer.stubGetApprovedOffenderContacts(prisonerId, contacts = ContactsDto(listOf(socialContactWithNoDOB, socialContactWithExpiredBannedRestriction, socialContactWithCurrentBannedRestriction)))
 
-    val returnResult = callGetSocialContacts(prisonerId, personId = socialUnapprovedContact.personId, withAddress = false)
+    val returnResult = callGetApprovedSocialContacts(prisonerId, personId = socialContactWithCurrentBannedRestriction.personId, withAddress = false)
       .expectStatus().isOk
       .expectBody()
 
     val contacts = getContactResults(returnResult)
     assertThat(contacts.size).isEqualTo(1)
-    assertContact(contacts[0], socialUnapprovedContact)
+    assertContact(contacts[0], socialContactWithCurrentBannedRestriction)
 
-    verify(prisonApiClientSpy, times(1)).getOffenderContacts(prisonerId, false)
+    verify(prisonApiClientSpy, times(1)).getOffenderContacts(prisonerId, true)
     verify(prisonApiClientSpy, times(0)).getPersonAddress(any())
   }
 
@@ -221,36 +213,36 @@ class PrisonerGetSocialContactsTest : IntegrationTestBase() {
   fun `when withAddress is false then no call is made to get address`() {
     val prisonerId = "A1234AA"
 
-    prisonApiMockServer.stubGetOffenderContacts(
+    prisonApiMockServer.stubGetApprovedOffenderContacts(
       prisonerId,
       contacts = ContactsDto(
         listOf(
           socialContactWithExpiredBannedRestriction,
-          socialUnapprovedContact,
+          socialContactWithCurrentBannedRestriction,
           officialContact,
         ),
       ),
     )
 
     prisonApiMockServer.stubGetPersonAddressesFullAddress(socialContactWithExpiredBannedRestriction.personId!!)
-    prisonApiMockServer.stubGetPersonAddressesFullAddress(socialUnapprovedContact.personId!!)
+    prisonApiMockServer.stubGetPersonAddressesFullAddress(socialContactWithCurrentBannedRestriction.personId!!)
     prisonApiMockServer.stubGetPersonAddressesFullAddress(officialContact.personId!!)
 
-    val returnResult = callGetSocialContacts(prisonerId, withAddress = false)
+    val returnResult = callGetApprovedSocialContacts(prisonerId, withAddress = false)
       .expectStatus().isOk
       .expectBody()
 
     val contacts = getContactResults(returnResult)
     assertThat(contacts.size).isEqualTo(2)
     val contact1 = contacts[0]
-    assertContact(contact1, socialContactWithExpiredBannedRestriction)
+    assertContact(contact1, socialContactWithCurrentBannedRestriction)
     assertThat(contact1.addresses).isEmpty()
 
     val contact2 = contacts[1]
-    assertContact(contact2, socialUnapprovedContact)
+    assertContact(contact2, socialContactWithExpiredBannedRestriction)
     assertThat(contact1.addresses).isEmpty()
 
-    verify(prisonApiClientSpy, times(1)).getOffenderContacts(prisonerId, false)
+    verify(prisonApiClientSpy, times(1)).getOffenderContacts(prisonerId, true)
     verify(prisonApiClientSpy, times(0)).getPersonAddress(any())
   }
 
@@ -258,84 +250,84 @@ class PrisonerGetSocialContactsTest : IntegrationTestBase() {
   fun `when hasDateOfBirth is passed as true only social contacts with a DOB are returned`() {
     val prisonerId = "A1234AA"
 
-    prisonApiMockServer.stubGetOffenderContacts(
+    prisonApiMockServer.stubGetApprovedOffenderContacts(
       prisonerId,
       contacts = ContactsDto(
         listOf(
           socialContactWithNoDOB,
           socialContactWithExpiredBannedRestriction,
-          socialUnapprovedContact,
+          socialContactWithCurrentBannedRestriction,
           officialContact,
         ),
       ),
     )
 
     prisonApiMockServer.stubGetPersonAddressesFullAddress(socialContactWithExpiredBannedRestriction.personId!!)
-    prisonApiMockServer.stubGetPersonAddressesFullAddress(socialUnapprovedContact.personId!!)
+    prisonApiMockServer.stubGetPersonAddressesFullAddress(socialContactWithCurrentBannedRestriction.personId!!)
     prisonApiMockServer.stubGetPersonAddressesFullAddress(officialContact.personId!!)
     prisonApiMockServer.stubGetPersonAddressesFullAddress(socialContactWithNoDOB.personId!!)
 
-    val returnResult = callGetSocialContacts(prisonerId, hasDateOfBirth = true)
+    val returnResult = callGetApprovedSocialContacts(prisonerId, hasDateOfBirth = true)
       .expectStatus().isOk
       .expectBody()
 
     val contacts = getContactResults(returnResult)
     assertThat(contacts.size).isEqualTo(2)
     val contact1 = contacts[0]
-    assertContact(contact1, socialContactWithExpiredBannedRestriction)
+    assertContact(contact1, socialContactWithCurrentBannedRestriction)
     assertContactAddress(contact1.addresses[0])
 
     val contact2 = contacts[1]
-    assertContact(contact2, socialUnapprovedContact)
+    assertContact(contact2, socialContactWithExpiredBannedRestriction)
     assertContactAddress(contact2.addresses[0])
 
-    verify(prisonApiClientSpy, times(1)).getOffenderContacts(prisonerId, false)
+    verify(prisonApiClientSpy, times(1)).getOffenderContacts(prisonerId, true)
     verify(prisonApiClientSpy, times(1)).getPersonAddress(socialContactWithExpiredBannedRestriction.personId!!)
-    verify(prisonApiClientSpy, times(1)).getPersonAddress(socialUnapprovedContact.personId!!)
+    verify(prisonApiClientSpy, times(1)).getPersonAddress(socialContactWithCurrentBannedRestriction.personId!!)
   }
 
   @Test
   fun `when hasDateOfBirth is passed as false all social contacts with or without a DOB are returned`() {
     val prisonerId = "A1234AA"
 
-    prisonApiMockServer.stubGetOffenderContacts(
+    prisonApiMockServer.stubGetApprovedOffenderContacts(
       prisonerId,
       contacts = ContactsDto(
         listOf(
           socialContactWithNoDOB,
           socialContactWithExpiredBannedRestriction,
-          socialUnapprovedContact,
+          socialContactWithCurrentBannedRestriction,
           officialContact,
         ),
       ),
     )
 
     prisonApiMockServer.stubGetPersonAddressesFullAddress(socialContactWithExpiredBannedRestriction.personId!!)
-    prisonApiMockServer.stubGetPersonAddressesFullAddress(socialUnapprovedContact.personId!!)
+    prisonApiMockServer.stubGetPersonAddressesFullAddress(socialContactWithCurrentBannedRestriction.personId!!)
     prisonApiMockServer.stubGetPersonAddressesFullAddress(officialContact.personId!!)
     prisonApiMockServer.stubGetPersonAddressesFullAddress(socialContactWithNoDOB.personId!!)
 
-    val returnResult = callGetSocialContacts(prisonerId, hasDateOfBirth = false)
+    val returnResult = callGetApprovedSocialContacts(prisonerId, hasDateOfBirth = false)
       .expectStatus().isOk
       .expectBody()
 
     val contacts = getContactResults(returnResult)
     assertThat(contacts.size).isEqualTo(3)
     val contact1 = contacts[0]
-    assertContact(contact1, socialContactWithExpiredBannedRestriction)
+    assertContact(contact1, socialContactWithCurrentBannedRestriction)
     assertContactAddress(contact1.addresses[0])
 
     val contact2 = contacts[1]
-    assertContact(contact2, socialUnapprovedContact)
+    assertContact(contact2, socialContactWithExpiredBannedRestriction)
     assertContactAddress(contact2.addresses[0])
 
     val contact3 = contacts[2]
     assertContact(contact3, socialContactWithNoDOB)
     assertContactAddress(contact3.addresses[0])
 
-    verify(prisonApiClientSpy, times(1)).getOffenderContacts(prisonerId, false)
+    verify(prisonApiClientSpy, times(1)).getOffenderContacts(prisonerId, true)
     verify(prisonApiClientSpy, times(1)).getPersonAddress(socialContactWithExpiredBannedRestriction.personId!!)
-    verify(prisonApiClientSpy, times(1)).getPersonAddress(socialUnapprovedContact.personId!!)
+    verify(prisonApiClientSpy, times(1)).getPersonAddress(socialContactWithCurrentBannedRestriction.personId!!)
     verify(prisonApiClientSpy, times(1)).getPersonAddress(socialContactWithNoDOB.personId!!)
   }
 
@@ -367,12 +359,12 @@ class PrisonerGetSocialContactsTest : IntegrationTestBase() {
       restrictions = listOf(banEndBeforeEndDateRestriction),
     )
 
-    prisonApiMockServer.stubGetOffenderContacts(
+    prisonApiMockServer.stubGetApprovedOffenderContacts(
       prisonerId,
       contacts = ContactsDto(
         listOf(
-          // returned - no restrictions, unapproved.
-          socialUnapprovedContact,
+          // returned - no restrictions
+          socialContactWithNoDOB,
           // returned - expired BANNED restriction
           socialContactWithExpiredBannedRestriction,
           // not returned - social contact with BANNED restriction with expiry date as NULL
@@ -389,17 +381,17 @@ class PrisonerGetSocialContactsTest : IntegrationTestBase() {
       ),
     )
 
-    val returnResult = callGetSocialContacts(prisonerId, notBannedBeforeDate = banEndDate, withAddress = false)
+    val returnResult = callGetApprovedSocialContacts(prisonerId, notBannedBeforeDate = banEndDate, withAddress = false)
       .expectStatus().isOk
       .expectBody()
 
     val contacts = getContactResults(returnResult)
     assertThat(contacts.size).isEqualTo(3)
-    assertContact(contacts[0], socialUnapprovedContact)
-    assertContact(contacts[1], socialContactWithExpiredBannedRestriction)
+    assertContact(contacts[0], socialContactWithExpiredBannedRestriction)
+    assertContact(contacts[1], socialContactWithNoDOB)
     assertContact(contacts[2], socialContactWithBanEndBeforeEndDate)
 
-    verify(prisonApiClientSpy, times(1)).getOffenderContacts(prisonerId, false)
+    verify(prisonApiClientSpy, times(1)).getOffenderContacts(prisonerId, true)
     verify(prisonApiClientSpy, times(0)).getPersonAddress(any())
   }
 
@@ -415,7 +407,7 @@ class PrisonerGetSocialContactsTest : IntegrationTestBase() {
       restrictions = listOf(banEndBeforeEndDateRestriction, indefinitelyBannedRestriction),
     )
 
-    prisonApiMockServer.stubGetOffenderContacts(
+    prisonApiMockServer.stubGetApprovedOffenderContacts(
       prisonerId,
       contacts = ContactsDto(
         listOf(
@@ -427,14 +419,49 @@ class PrisonerGetSocialContactsTest : IntegrationTestBase() {
       ),
     )
 
-    val returnResult = callGetSocialContacts(prisonerId, notBannedBeforeDate = banEndDate, withAddress = false)
+    val returnResult = callGetApprovedSocialContacts(prisonerId, notBannedBeforeDate = banEndDate, withAddress = false)
       .expectStatus().isOk
       .expectBody()
 
     val contacts = getContactResults(returnResult)
     assertThat(contacts).isEmpty()
 
-    verify(prisonApiClientSpy, times(1)).getOffenderContacts(prisonerId, false)
+    verify(prisonApiClientSpy, times(1)).getOffenderContacts(prisonerId, true)
+    verify(prisonApiClientSpy, times(0)).getPersonAddress(any())
+  }
+
+  @Test
+  fun `when bannedDate is passed and contact has multiple bans with one expiring after end date most relevant ban is used`() {
+    val prisonerId = "A1234AA"
+
+    val socialContactWithMultipleBans = createContact(
+      lastName = "GBannedVisitor",
+      firstName = "Social",
+      dateOfBirth = LocalDate.of(1951, 9, 13),
+      personId = 8L,
+      restrictions = listOf(banEndBeforeEndDateRestriction, banEndAfterEndDateRestriction),
+    )
+
+    prisonApiMockServer.stubGetApprovedOffenderContacts(
+      prisonerId,
+      contacts = ContactsDto(
+        listOf(
+          // not returned
+          socialContactWithMultipleBans,
+          // not returned - official contact
+          officialContact,
+        ),
+      ),
+    )
+
+    val returnResult = callGetApprovedSocialContacts(prisonerId, notBannedBeforeDate = banEndDate, withAddress = false)
+      .expectStatus().isOk
+      .expectBody()
+
+    val contacts = getContactResults(returnResult)
+    assertThat(contacts).isEmpty()
+
+    verify(prisonApiClientSpy, times(1)).getOffenderContacts(prisonerId, true)
     verify(prisonApiClientSpy, times(0)).getPersonAddress(any())
   }
 
@@ -442,12 +469,12 @@ class PrisonerGetSocialContactsTest : IntegrationTestBase() {
   fun `when 404 returned from prison API get contacts 404 is returned`() {
     val prisonerId = "A1234AA"
 
-    prisonApiMockServer.stubGetOffenderNotFound(prisonerId)
+    prisonApiMockServer.stubGetApprovedOffenderContacts(prisonerId, contacts = null)
 
-    val responseSpec = callGetSocialContacts(prisonerId, notBannedBeforeDate = banEndDate, withAddress = false)
+    val responseSpec = callGetApprovedSocialContacts(prisonerId, notBannedBeforeDate = banEndDate, withAddress = false)
       .expectStatus().isNotFound
 
-    verify(prisonApiClientSpy, times(1)).getOffenderContacts(prisonerId, false)
+    verify(prisonApiClientSpy, times(1)).getOffenderContacts(prisonerId, true)
     verify(prisonApiClientSpy, times(0)).getPersonAddress(any())
     assertErrorResult(responseSpec, HttpStatus.NOT_FOUND, "Contacts not found for - $prisonerId on prison-api")
   }
@@ -456,12 +483,12 @@ class PrisonerGetSocialContactsTest : IntegrationTestBase() {
   fun `when BAD_REQUEST returned from prison API get contacts BAD_REQUEST is returned`() {
     val prisonerId = "A1234AA"
 
-    prisonApiMockServer.stubGetOffenderBadRequest(prisonerId)
+    prisonApiMockServer.stubGetApprovedOffenderContacts(prisonerId, contacts = null, HttpStatus.BAD_REQUEST)
 
-    callGetSocialContacts(prisonerId, notBannedBeforeDate = banEndDate, withAddress = false)
+    callGetApprovedSocialContacts(prisonerId, notBannedBeforeDate = banEndDate, withAddress = false)
       .expectStatus().isBadRequest
 
-    verify(prisonApiClientSpy, times(1)).getOffenderContacts(prisonerId, false)
+    verify(prisonApiClientSpy, times(1)).getOffenderContacts(prisonerId, true)
     verify(prisonApiClientSpy, times(0)).getPersonAddress(any())
   }
 
@@ -469,13 +496,13 @@ class PrisonerGetSocialContactsTest : IntegrationTestBase() {
   fun `when 404 returned from prison API get contact address only contact data is returned`() {
     val prisonerId = "A1234AA"
 
-    prisonApiMockServer.stubGetOffenderContacts(
+    prisonApiMockServer.stubGetApprovedOffenderContacts(
       prisonerId,
       contacts = ContactsDto(listOf(socialContactWithExpiredBannedRestriction)),
     )
     prisonApiMockServer.stubGetPersonNotFound(socialContactWithExpiredBannedRestriction.personId!!)
 
-    val returnResult = callGetSocialContacts(prisonerId)
+    val returnResult = callGetApprovedSocialContacts(prisonerId)
       .expectStatus().isOk
       .expectBody()
 
@@ -484,7 +511,7 @@ class PrisonerGetSocialContactsTest : IntegrationTestBase() {
     assertThat(contacts[0]).isEqualTo(socialContactWithExpiredBannedRestriction)
     assertThat(contacts[0].addresses.size).isEqualTo(0)
 
-    verify(prisonApiClientSpy, times(1)).getOffenderContacts(prisonerId, false)
+    verify(prisonApiClientSpy, times(1)).getOffenderContacts(prisonerId, true)
     verify(prisonApiClientSpy, times(1)).getPersonAddress(any())
   }
 
@@ -499,6 +526,15 @@ class PrisonerGetSocialContactsTest : IntegrationTestBase() {
         objectMapper.readValue(responseSpec.expectBody().returnResult().responseBody, ErrorResponse::class.java)
       assertThat(errorResponse.developerMessage).isEqualTo(errorMessage)
     }
+  }
+
+  @Test
+  fun `bad request`() {
+    val prisonerId = "A1234AA"
+    webTestClient.get().uri("/prisoners/$prisonerId/contacts?id=ABC")
+      .headers(setAuthorisation(roles = listOf("ROLE_PRISONER_CONTACT_REGISTRY")))
+      .exchange()
+      .expectStatus().isBadRequest
   }
 
   private fun getContactResults(returnResult: WebTestClient.BodyContentSpec): Array<ContactDto> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/mock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/mock/PrisonApiMockServer.kt
@@ -46,6 +46,28 @@ class PrisonApiMockServer : WireMockServer(8092) {
     )
   }
 
+  fun stubGetOffenderSocialContacts(
+    offenderNo: String,
+    contacts: ContactsDto? = null,
+    httpStatus: HttpStatus = NOT_FOUND,
+  ) {
+    stubFor(
+      get("/api/offenders/$offenderNo/contacts")
+        .willReturn(
+          if (contacts != null) {
+            aResponse()
+              .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+              .withStatus(200)
+              .withBody(getJsonString(contacts))
+          } else {
+            aResponse()
+              .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+              .withStatus(httpStatus.value())
+          },
+        ),
+    )
+  }
+
   fun stubGetOffenderNotFound(offenderNo: String) {
     stubFor(
       get("/api/offenders/$offenderNo/contacts")
@@ -53,17 +75,6 @@ class PrisonApiMockServer : WireMockServer(8092) {
           aResponse()
             .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
             .withStatus(HttpStatus.NOT_FOUND.value()),
-        ),
-    )
-  }
-
-  fun stubGetOffenderBadRequest(offenderNo: String) {
-    stubFor(
-      get("/api/offenders/$offenderNo/contacts")
-        .willReturn(
-          aResponse()
-            .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-            .withStatus(HttpStatus.BAD_REQUEST.value()),
         ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/mock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/mock/PrisonApiMockServer.kt
@@ -52,7 +52,18 @@ class PrisonApiMockServer : WireMockServer(8092) {
         .willReturn(
           aResponse()
             .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-            .withStatus(404),
+            .withStatus(HttpStatus.NOT_FOUND.value()),
+        ),
+    )
+  }
+
+  fun stubGetOffenderBadRequest(offenderNo: String) {
+    stubFor(
+      get("/api/offenders/$offenderNo/contacts")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+            .withStatus(HttpStatus.BAD_REQUEST.value()),
         ),
     )
   }


### PR DESCRIPTION
## What does this pull request do?

Create a new "social contacts" endpoint which will handle all pulling back social contact details (with a new flag approvedVisitorsOnly, to hide unapproved if set to true).

Deprecate the old "approved social contacts' endpoint for removal in the future, as we can use the new endpoint and pass in the flag as true. 

## JIRA Internal Link
https://dsdmoj.atlassian.net/browse/VB-4000