### PR TITLE
VB-5723 - New endpoint to get date ranges of visitor restrictions that can effect request bookings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/PrisonerContactControllerV2.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/PrisonerContactControllerV2.kt
@@ -256,16 +256,16 @@ class PrisonerContactControllerV2(
   @PreAuthorize("hasRole('PRISONER_CONTACT_REGISTRY')")
   @PostMapping(V2_PRISONER_GET_REQUEST_VISIT_RESTRICTION_DATE_RANGES_CONTROLLER_PATH)
   @Operation(
-    summary = "Get an updated date range for visitors if a visitor with ban restriction is found, else returns original date",
-    description = "Returns an updated date range for visitors if one is found with an active ban restriction. If not, it returns the original date range",
+    summary = "Get all date ranges of visitor restrictions which would cause a visit to be a request visit",
+    description = "Returns a List<DateRangeDto> containing all start/end date pairs of visitor restrictions which cause a visit to be a request visit",
     responses = [
       ApiResponse(
         responseCode = "200",
-        description = "Date range returned (original or adjusted)",
+        description = "Date ranges returned (empty if none cause sessions to be request visits)",
       ),
       ApiResponse(
         responseCode = "400",
-        description = "Incorrect request to Get date range for prisoner visitors",
+        description = "Incorrect request to Get date ranges for prisoner visitors",
         content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
       ),
       ApiResponse(
@@ -275,12 +275,12 @@ class PrisonerContactControllerV2(
       ),
       ApiResponse(
         responseCode = "403",
-        description = "Incorrect permissions to Get date range for prisoner visitors",
+        description = "Incorrect permissions to Get date ranges for prisoner visitors",
         content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
       ),
       ApiResponse(
         responseCode = "404",
-        description = "Prisoner, Visitor or Date range not found",
+        description = "Prisoner or Visitor not found",
         content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
       ),
     ],

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/PrisonerContactControllerV2.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/PrisonerContactControllerV2.kt
@@ -26,12 +26,6 @@ import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.visit.scheduler.
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.service.PrisonerContactRegistryServiceV2
 import java.time.LocalDate
 
-// TODO: Get sessions date ranges ticket https://dsdmoj.atlassian.net/browse/VB-5723 for more detailed info
-//  A. New endpoint (similar to the BAN_DATE_RANGE endpoint structure)
-//  B. Takes a prisonerId, visitorIds, existing date range, list of supported restrictions
-//  C. Find all visitor restrictions, filter to only keep the ones that are in the list of supported restrictions
-//  D. Check if restrictions contains a null expiry (send back original date range), if not, get all date ranges (unique) into a List and return
-
 const val V2_PRISONER_CONTACTS_CONTROLLER_PATH: String = "v2/prisoners/{prisonerId}"
 const val V2_PRISONER_GET_SOCIAL_CONTACTS_CONTROLLER_PATH: String = "$V2_PRISONER_CONTACTS_CONTROLLER_PATH/contacts/social"
 const val V2_PRISONER_GET_SOCIAL_CONTACTS_APPROVED_CONTROLLER_PATH: String = "$V2_PRISONER_GET_SOCIAL_CONTACTS_CONTROLLER_PATH/approved"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/visit/scheduler/RequestVisitVisitorRestrictionsBodyDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/visit/scheduler/RequestVisitVisitorRestrictionsBodyDto.kt
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.DateRangeDto
 
-@Schema(description = "A contact for a prisoner")
+@Schema(description = "Request body for finding visitor restriction date ranges which would effect request visits")
 data class RequestVisitVisitorRestrictionsBodyDto(
   @param:Schema(description = "Prisoner Id of prisoner who the visit is for", required = true)
   @field:NotBlank

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/visit/scheduler/RequestVisitVisitorRestrictionsBodyDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/visit/scheduler/RequestVisitVisitorRestrictionsBodyDto.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.visit.scheduler
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.DateRangeDto
+
+@Schema(description = "A contact for a prisoner")
+data class RequestVisitVisitorRestrictionsBodyDto(
+  @param:Schema(description = "Prisoner Id of prisoner who the visit is for", required = true)
+  @field:NotBlank
+  val prisonerId: String,
+
+  @param:Schema(description = "List of all visitors attending the visit", required = true)
+  @field:NotEmpty
+  val visitorIds: List<String>,
+
+  @param:Schema(description = "A list of restriction codes to search for when finding visitor restrictions", required = true)
+  val supportedVisitorRestrictionsCodesForRequestVisits: List<String>,
+
+  @param:Schema(description = "The current visit booking window date range (used to limit restriction search)", required = true)
+  val currentDateRange: DateRangeDto,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/service/PrisonerContactRegistryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/service/PrisonerContactRegistryService.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.prisonercontactregistry.exception.PrisonerNo
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.exception.VisitorNotFoundException
 import java.time.LocalDate
 
+@Deprecated("Use PrisonerContactRegistryServiceV2 instead")
 @Service
 class PrisonerContactRegistryService(private val prisonApiClient: PrisonApiClient) {
   companion object {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/GetDateRangeVisitorRestrictionsWhichEffectRequestVisitsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/GetDateRangeVisitorRestrictionsWhichEffectRequestVisitsTest.kt
@@ -1,0 +1,355 @@
+package uk.gov.justice.digital.hmpps.prisonercontactregistry.integration
+
+import com.fasterxml.jackson.core.type.TypeReference
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.web.reactive.function.BodyInserters
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.client.PrisonApiClient
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.ContactDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.ContactsDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.DateRangeDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.RestrictionDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.visit.scheduler.RequestVisitVisitorRestrictionsBodyDto
+import java.time.LocalDate
+
+@Suppress("ClassName")
+class GetDateRangeVisitorRestrictionsWhichEffectRequestVisitsTest : IntegrationTestBase() {
+
+  @MockitoSpyBean
+  private lateinit var prisonApiClient: PrisonApiClient
+
+  @Nested
+  inner class authentication {
+    @Test
+    fun `Get date ranges for visitors restrictions which effect request visits - requires authentication`() {
+      // Given
+      val requestDto = RequestVisitVisitorRestrictionsBodyDto(
+        prisonerId = "A1234AA",
+        visitorIds = listOf("2187525"),
+        supportedVisitorRestrictionsCodesForRequestVisits = listOf("CHILD"),
+        currentDateRange = DateRangeDto(fromDate = LocalDate.now().plusDays(2), toDate = LocalDate.now().plusDays(28)),
+      )
+
+      // When
+      val result = callDateRangeVisitorRestrictionsWhichEffectRequestVisitsUri(webTestClient, requestDto, setAuthorisation(roles = listOf()))
+
+      // Then
+      result.expectStatus().isForbidden
+    }
+
+    @Test
+    fun `Get date ranges for visitors restrictions which effect request visits - requires correct role PRISONER_CONTACT_REGISTRY`() {
+      // Given
+      val requestDto = RequestVisitVisitorRestrictionsBodyDto(
+        prisonerId = "A1234AA",
+        visitorIds = listOf("2187525"),
+        supportedVisitorRestrictionsCodesForRequestVisits = listOf("CHILD"),
+        currentDateRange = DateRangeDto(fromDate = LocalDate.now().plusDays(2), toDate = LocalDate.now().plusDays(28)),
+      )
+
+      prisonApiMockServer.stubGetApprovedOffenderContacts(
+        requestDto.prisonerId,
+        contacts = createContactsDto(restrictions = listOf(), requestDto.visitorIds.map { it.toLong() }.toList()),
+      )
+
+      // When
+      val result = callDateRangeVisitorRestrictionsWhichEffectRequestVisitsUri(webTestClient, requestDto, setAuthorisation(roles = listOf("ROLE_PRISONER_CONTACT_REGISTRY")))
+
+      // Then
+      result.expectStatus().isOk
+    }
+  }
+
+  @Test
+  fun `Get date ranges for visitors restrictions which effect request visits - bad request`() {
+    // Given
+    val requestDto = RequestVisitVisitorRestrictionsBodyDto(
+      prisonerId = "AA12345",
+      visitorIds = listOf(),
+      supportedVisitorRestrictionsCodesForRequestVisits = listOf("CHILD"),
+      currentDateRange = DateRangeDto(fromDate = LocalDate.now().plusDays(2), toDate = LocalDate.now().plusDays(28)),
+    )
+
+    // When
+    val result = callDateRangeVisitorRestrictionsWhichEffectRequestVisitsUri(webTestClient, requestDto, setAuthorisation(roles = listOf("ROLE_PRISONER_CONTACT_REGISTRY")))
+
+    // Then
+    result.expectStatus().is5xxServerError
+  }
+
+  @Test
+  fun `Get date ranges for visitors restrictions which effect request visits - visitorId not found within list of prisoner contacts`() {
+    // Given
+    val requestDto = RequestVisitVisitorRestrictionsBodyDto(
+      prisonerId = "A1234AA",
+      visitorIds = listOf("2187524", "2187525"),
+      supportedVisitorRestrictionsCodesForRequestVisits = listOf("CHILD"),
+      currentDateRange = DateRangeDto(fromDate = LocalDate.now().plusDays(2), toDate = LocalDate.now().plusDays(28)),
+    )
+
+    val contactWithMinimumDetails = ContactDto(
+      lastName = "Ireron",
+      firstName = "Ehicey",
+      contactType = "S",
+      relationshipCode = "PROB",
+      relationshipDescription = "Probation Officer",
+      commentText = "Comment Here",
+      emergencyContact = false,
+      nextOfKin = false,
+      personId = 2187524,
+      approvedVisitor = false,
+      restrictions = listOf(),
+    )
+
+    prisonApiMockServer.stubGetApprovedOffenderContacts(
+      requestDto.prisonerId,
+      contacts = ContactsDto(listOf(contactWithMinimumDetails)),
+    )
+
+    // When
+    val result = callDateRangeVisitorRestrictionsWhichEffectRequestVisitsUri(webTestClient, requestDto, setAuthorisation(roles = listOf("ROLE_PRISONER_CONTACT_REGISTRY")))
+
+    // Then
+    result.expectStatus().isNotFound
+    result.expectBody()
+      .jsonPath("$.userMessage")
+      .isEqualTo("One of the visitors provided could not found")
+      .jsonPath("$.developerMessage")
+      .isEqualTo("Not all visitors provided (${requestDto.visitorIds}) are contacts for prisoner ${requestDto.prisonerId}")
+  }
+
+  @Test
+  fun `Get date ranges for visitors restrictions which effect request visits - No restrictions found for visitors`() {
+    // Given
+    val requestDto = RequestVisitVisitorRestrictionsBodyDto(
+      prisonerId = "A1234AA",
+      visitorIds = listOf("2187524", "2187525"),
+      supportedVisitorRestrictionsCodesForRequestVisits = listOf("CHILD"),
+      currentDateRange = DateRangeDto(fromDate = LocalDate.now().plusDays(2), toDate = LocalDate.now().plusDays(28)),
+    )
+
+    prisonApiMockServer.stubGetApprovedOffenderContacts(
+      requestDto.prisonerId,
+      contacts = createContactsDto(listOf(), requestDto.visitorIds.map { it.toLong() }.toList()),
+    )
+
+    // When
+    val result = callDateRangeVisitorRestrictionsWhichEffectRequestVisitsUri(webTestClient, requestDto, setAuthorisation(roles = listOf("ROLE_PRISONER_CONTACT_REGISTRY")))
+
+    // Then
+    result.expectStatus().isOk
+    val foundDateRanges = getResults(result)
+    assert(foundDateRanges.isEmpty())
+  }
+
+  @Test
+  fun `Get date ranges for visitors restrictions which effect request visits - Restriction with no expiry date found for visitors, later start date`() {
+    // Given
+    val requestDto = RequestVisitVisitorRestrictionsBodyDto(
+      prisonerId = "A1234AA",
+      visitorIds = listOf("2187524", "2187525"),
+      supportedVisitorRestrictionsCodesForRequestVisits = listOf("CHILD"),
+      currentDateRange = DateRangeDto(fromDate = LocalDate.now().plusDays(2), toDate = LocalDate.now().plusDays(28)),
+    )
+
+    val restrictions = listOf(
+      RestrictionDto(
+        restrictionId = 123,
+        comment = "Comment Here",
+        restrictionType = "CHILD",
+        restrictionTypeDescription = "Banned",
+        startDate = LocalDate.now().plusDays(5),
+        expiryDate = null,
+        globalRestriction = false,
+      ),
+      RestrictionDto(
+        restrictionId = 345,
+        comment = "Comment Here",
+        restrictionType = "OTHER",
+        restrictionTypeDescription = "Banned",
+        startDate = LocalDate.now(),
+        expiryDate = LocalDate.now().plusDays(1),
+        globalRestriction = false,
+      ),
+    )
+
+    prisonApiMockServer.stubGetApprovedOffenderContacts(
+      requestDto.prisonerId,
+      contacts = createContactsDto(restrictions, requestDto.visitorIds.map { it.toLong() }.toList()),
+    )
+
+    // When
+    val result = callDateRangeVisitorRestrictionsWhichEffectRequestVisitsUri(webTestClient, requestDto, setAuthorisation(roles = listOf("ROLE_PRISONER_CONTACT_REGISTRY")))
+
+    // Then
+    result.expectStatus().isOk
+    val foundDateRanges = getResults(result)
+    val expected = listOf(DateRangeDto(fromDate = LocalDate.now().plusDays(5), toDate = LocalDate.now().plusDays(28)))
+    assertThat(foundDateRanges).isEqualTo(expected)
+  }
+
+  @Test
+  fun `Get date ranges for visitors restrictions which effect request visits - Restriction with no expiry date found for visitors, earlier start date`() {
+    // Given
+    val requestDto = RequestVisitVisitorRestrictionsBodyDto(
+      prisonerId = "A1234AA",
+      visitorIds = listOf("2187524", "2187525"),
+      supportedVisitorRestrictionsCodesForRequestVisits = listOf("CHILD"),
+      currentDateRange = DateRangeDto(fromDate = LocalDate.now().plusDays(2), toDate = LocalDate.now().plusDays(28)),
+    )
+
+    val restrictions = listOf(
+      RestrictionDto(
+        restrictionId = 123,
+        comment = "Comment Here",
+        restrictionType = "CHILD",
+        restrictionTypeDescription = "Banned",
+        startDate = LocalDate.now().minusDays(1),
+        expiryDate = null,
+        globalRestriction = false,
+      ),
+      RestrictionDto(
+        restrictionId = 345,
+        comment = "Comment Here",
+        restrictionType = "OTHER",
+        restrictionTypeDescription = "Banned",
+        startDate = LocalDate.now(),
+        expiryDate = LocalDate.now().plusDays(1),
+        globalRestriction = false,
+      ),
+    )
+
+    prisonApiMockServer.stubGetApprovedOffenderContacts(
+      requestDto.prisonerId,
+      contacts = createContactsDto(restrictions, requestDto.visitorIds.map { it.toLong() }.toList()),
+    )
+
+    // When
+    val result = callDateRangeVisitorRestrictionsWhichEffectRequestVisitsUri(webTestClient, requestDto, setAuthorisation(roles = listOf("ROLE_PRISONER_CONTACT_REGISTRY")))
+
+    // Then
+    result.expectStatus().isOk
+    val foundDateRanges = getResults(result)
+    val expected = listOf(DateRangeDto(fromDate = LocalDate.now().plusDays(2), toDate = LocalDate.now().plusDays(28)))
+
+    assertThat(foundDateRanges).isEqualTo(expected)
+  }
+
+  @Test
+  fun `Get date ranges for visitors restrictions which effect request visits - Restriction found and date ranges returned`() {
+    // Given
+    val requestDto = RequestVisitVisitorRestrictionsBodyDto(
+      prisonerId = "A1234AA",
+      visitorIds = listOf("2187524", "2187525"),
+      supportedVisitorRestrictionsCodesForRequestVisits = listOf("CHILD"),
+      currentDateRange = DateRangeDto(fromDate = LocalDate.now().plusDays(2), toDate = LocalDate.now().plusDays(28)),
+    )
+
+    val restrictions = listOf(
+      RestrictionDto(
+        restrictionId = 123,
+        comment = "Comment Here",
+        restrictionType = "CHILD",
+        restrictionTypeDescription = "Banned",
+        startDate = LocalDate.now().plusDays(5),
+        expiryDate = LocalDate.now().plusDays(10),
+        globalRestriction = false,
+      ),
+      RestrictionDto(
+        restrictionId = 345,
+        comment = "Comment Here",
+        restrictionType = "CHILD",
+        restrictionTypeDescription = "Banned",
+        startDate = LocalDate.now(),
+        expiryDate = LocalDate.now().plusDays(3),
+        globalRestriction = false,
+      ),
+    )
+
+    prisonApiMockServer.stubGetApprovedOffenderContacts(
+      requestDto.prisonerId,
+      contacts = createContactsDto(restrictions, requestDto.visitorIds.map { it.toLong() }.toList()),
+    )
+
+    // When
+    val result = callDateRangeVisitorRestrictionsWhichEffectRequestVisitsUri(webTestClient, requestDto, setAuthorisation(roles = listOf("ROLE_PRISONER_CONTACT_REGISTRY")))
+
+    // Then
+    result.expectStatus().isOk
+    val foundDateRanges = getResults(result)
+    val expected = listOf(
+      DateRangeDto(fromDate = LocalDate.now(), toDate = LocalDate.now().plusDays(3)),
+      DateRangeDto(fromDate = LocalDate.now().plusDays(5), toDate = LocalDate.now().plusDays(10)),
+    )
+
+    assertThat(foundDateRanges).containsExactlyInAnyOrderElementsOf(expected)
+  }
+
+  @Test
+  fun `Get date ranges for visitors restrictions which effect request visits - Unsupported restrictions filtered`() {
+    // Given
+    val requestDto = RequestVisitVisitorRestrictionsBodyDto(
+      prisonerId = "A1234AA",
+      visitorIds = listOf("2187524", "2187525"),
+      supportedVisitorRestrictionsCodesForRequestVisits = listOf("CHILD"),
+      currentDateRange = DateRangeDto(fromDate = LocalDate.now().plusDays(2), toDate = LocalDate.now().plusDays(28)),
+    )
+
+    val restrictions = listOf(
+      RestrictionDto(
+        restrictionId = 123,
+        comment = "Comment Here",
+        restrictionType = "CHILD",
+        restrictionTypeDescription = "Banned",
+        startDate = LocalDate.now().plusDays(5),
+        expiryDate = LocalDate.now().plusDays(10),
+        globalRestriction = false,
+      ),
+      RestrictionDto(
+        restrictionId = 345,
+        comment = "Comment Here",
+        restrictionType = "UNSUPPORTED",
+        restrictionTypeDescription = "Banned",
+        startDate = LocalDate.now(),
+        expiryDate = LocalDate.now().plusDays(3),
+        globalRestriction = false,
+      ),
+    )
+
+    prisonApiMockServer.stubGetApprovedOffenderContacts(
+      requestDto.prisonerId,
+      contacts = createContactsDto(restrictions, requestDto.visitorIds.map { it.toLong() }.toList()),
+    )
+
+    // When
+    val result = callDateRangeVisitorRestrictionsWhichEffectRequestVisitsUri(webTestClient, requestDto, setAuthorisation(roles = listOf("ROLE_PRISONER_CONTACT_REGISTRY")))
+
+    // Then
+    result.expectStatus().isOk
+    val foundDateRanges = getResults(result)
+    val expected = listOf(
+      DateRangeDto(fromDate = LocalDate.now().plusDays(5), toDate = LocalDate.now().plusDays(10)),
+    )
+
+    assertThat(foundDateRanges).containsExactlyInAnyOrderElementsOf(expected)
+  }
+
+  private fun callDateRangeVisitorRestrictionsWhichEffectRequestVisitsUri(
+    webTestClient: WebTestClient,
+    requestDto: RequestVisitVisitorRestrictionsBodyDto,
+    authHttpHeaders: (HttpHeaders) -> Unit,
+  ): WebTestClient.ResponseSpec {
+    val uri = "v2/prisoners/${requestDto.prisonerId}/contacts/social/approved/restrictions/visit-request/date-ranges"
+
+    return webTestClient.post().uri(uri)
+      .headers(authHttpHeaders)
+      .body(BodyInserters.fromValue(requestDto))
+      .exchange()
+  }
+
+  private fun getResults(responseSpec: WebTestClient.ResponseSpec): List<DateRangeDto> = objectMapper.readValue(responseSpec.expectBody().returnResult().responseBody!!, object : TypeReference<List<DateRangeDto>>() {})
+}


### PR DESCRIPTION
## What does this pull request do?
As part of a new feature (Request a visit) we need to capture all visitor restriction start/end dates to work out if sessions cross over these dates and if they do, they will be request sessions.

Added new endpoint / service / tests

new service will get contacts, find their restrictions and filter to keep only supported (passed in via DTO) and then capture their date ranges and return them in a list.

## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-5511
https://dsdmoj.atlassian.net/browse/VB-5723