### PR TITLE
Bug fix - incorrect validation on contacts being returned checking array size

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/service/PrisonerContactRegistryServiceV2.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/service/PrisonerContactRegistryServiceV2.kt
@@ -150,7 +150,7 @@ class PrisonerContactRegistryServiceV2(private val prisonApiClient: PrisonApiCli
     val contacts = getContactsByPrisonerId(prisonerId, true)
       .filter { visitorIds.contains(it.personId) }
 
-    if (contacts.size != visitorIds.size) {
+    if (!contacts.map { it.personId }.containsAll(visitorIds)) {
       throw VisitorNotFoundException(message = "Not all visitors provided ($visitorIds) are listed contacts for prisoner $prisonerId")
     }
 


### PR DESCRIPTION
## What does this pull request do?

instead of checking size, check all visitorIds are present. This handles an issue where duplicate visitorIds can be returned, creating a disparity with the expected size, which resulted in the exception being thrown.

Now checking if the contacts list contains our visitorIds.

## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-5941