### PR TITLE
Bug - some prisoners have over 350 contacts, causing some to not be returned

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/client/PersonalRelationshipsApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/client/PersonalRelationshipsApiClient.kt
@@ -94,7 +94,7 @@ class PersonalRelationshipsApiClient(
           .path(uri)
           .queryParam("relationshipType", "S")
           .queryParam("page", 0)
-          .queryParam("size", 350)
+          .queryParam("size", 400)
           .apply {
             // Only set this param if it's true. Setting it to false returns only unapproved visitors (we do not want this).
             if (approvedVisitorOnly) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/mock/PersonalRelationshipsApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/mock/PersonalRelationshipsApiMockServer.kt
@@ -46,7 +46,7 @@ class PersonalRelationshipsApiMockServer : WireMockServer(8093) {
     contacts: List<PersonalRelationshipsContactDto>? = null,
     approvedVisitorOnly: Boolean = false,
     page: Int = 0,
-    size: Int = 350,
+    size: Int = 400,
     httpStatus: HttpStatus = HttpStatus.OK,
   ) {
     val uri = "/prisoner/$prisonerId/contact"


### PR DESCRIPTION
## What does this pull request do?

Increase limit to 400 to fix this.