### PR TITLE
VB-6616 - Part 2 - New endpoint to get contact

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/client/PersonalRelationshipsApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/client/PersonalRelationshipsApiClient.kt
@@ -9,9 +9,11 @@ import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.ContactDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.PrisonerContactDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.RestrictionDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.GlobalContactRestrictionDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PersonalRelationshipsContactDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PersonalRelationshipsPrisonerContactDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PrisonerContactIdsRequestDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PrisonerContactRestrictionsResponseDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.exception.PersonNotFoundException
@@ -33,13 +35,59 @@ class PersonalRelationshipsApiClient(
     val logger: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun getPrisonerContactViaRelationshipId(prisonerId: String, contactId: String, relationshipId: Long, withRestrictions: Boolean): ContactDto? {
+  fun getContact(contactId: Long): ContactDto {
+    val uri = "/contact/$contactId"
+
+    logger.info("Get a contact using contactId called $uri, via the personal-relationships-api")
+
+    val contact = webClient
+      .get()
+      .uri(uri)
+      .retrieve()
+      .bodyToMono(object : ParameterizedTypeReference<PersonalRelationshipsContactDto>() {})
+      .onErrorResume { e ->
+        if (!clientUtils.isNotFoundError(e)) {
+          logger.error("get contact returned an error for get request $uri")
+          Mono.error(e)
+        } else {
+          logger.error("get contact returned NOT_FOUND for get request $uri")
+          Mono.error { PersonNotFoundException("Contact with id $contactId not found", cause = e) }
+        }
+      }
+      .blockOptional(apiTimeout).orElseThrow { IllegalStateException("Timeout getting a contact for uri $uri on personal-relationships-api") }
+
+    return ContactDto(personalRelationshipsContact = contact)
+  }
+
+  fun getContactGlobalRestrictions(contactId: Long): List<GlobalContactRestrictionDto> {
+    val uri = "/contact/$contactId/restriction"
+
+    logger.info("Get a contact's global restrictions called $uri, via the personal-relationships-api")
+
+    return webClient
+      .get()
+      .uri(uri)
+      .retrieve()
+      .bodyToMono(object : ParameterizedTypeReference<List<GlobalContactRestrictionDto>>() {})
+      .onErrorResume { e ->
+        if (!clientUtils.isNotFoundError(e)) {
+          logger.error("get contact's global restrictions returned an error for get request $uri")
+          Mono.error(e)
+        } else {
+          logger.error("get contact's global restrictions returned NOT_FOUND for get request $uri")
+          Mono.error { PersonNotFoundException("Contact with id $contactId not found", cause = e) }
+        }
+      }
+      .blockOptional(apiTimeout).orElseThrow { IllegalStateException("Timeout getting a contact's global restrictions for uri $uri on personal-relationships-api") }
+  }
+
+  fun getPrisonerContactViaRelationshipId(prisonerId: String, contactId: String, relationshipId: Long, withRestrictions: Boolean): PrisonerContactDto? {
     val uri = "/prisoner/$prisonerId/contact/$contactId"
 
     val contactRelationships = webClient.get()
       .uri(uri)
       .retrieve()
-      .bodyToMono(object : ParameterizedTypeReference<List<PersonalRelationshipsContactDto>>() {})
+      .bodyToMono(object : ParameterizedTypeReference<List<PersonalRelationshipsPrisonerContactDto>>() {})
       .onErrorResume { e ->
         if (!clientUtils.isNotFoundError(e)) {
           logger.error("getPrisonerContactViaRelationshipId Failed for get request $uri")
@@ -66,7 +114,7 @@ class PersonalRelationshipsApiClient(
     return convertToContactDto(listOf(contactRelationships), allPrisonerContactRestrictions).firstOrNull()
   }
 
-  fun getPrisonerContacts(prisonerId: String, approvedVisitorOnly: Boolean, withRestrictions: Boolean): List<ContactDto> {
+  fun getPrisonerContacts(prisonerId: String, approvedVisitorOnly: Boolean, withRestrictions: Boolean): List<PrisonerContactDto> {
     logger.info("Get prisoner contacts called for $prisonerId, via the personal-relationships-api")
 
     // 1 - Get the contacts
@@ -85,7 +133,7 @@ class PersonalRelationshipsApiClient(
     return convertToContactDto(prisonerContacts, allPrisonerContactRestrictions)
   }
 
-  private fun getAllContacts(prisonerId: String, approvedVisitorOnly: Boolean): List<PersonalRelationshipsContactDto> {
+  private fun getAllContacts(prisonerId: String, approvedVisitorOnly: Boolean): List<PersonalRelationshipsPrisonerContactDto> {
     val uri = "/prisoner/$prisonerId/contact"
 
     return webClient.get()
@@ -103,7 +151,7 @@ class PersonalRelationshipsApiClient(
           }.build()
       }
       .retrieve()
-      .bodyToMono(object : ParameterizedTypeReference<PagedResponse<PersonalRelationshipsContactDto>>() {})
+      .bodyToMono(object : ParameterizedTypeReference<PagedResponse<PersonalRelationshipsPrisonerContactDto>>() {})
       .onErrorResume { e ->
         if (!clientUtils.isNotFoundError(e)) {
           logger.error("get prisoner contacts Failed for get request $uri")
@@ -136,28 +184,6 @@ class PersonalRelationshipsApiClient(
       .blockOptional(apiTimeout).orElseThrow { IllegalStateException("Timeout getting contact restrictions for uri $uri on personal-relationships-api") }
   }
 
-  fun getContactGlobalRestrictions(contactId: Long): List<GlobalContactRestrictionDto> {
-    val uri = "/contact/$contactId/restriction"
-
-    logger.info("Get a contact's global restrictions called $uri, via the personal-relationships-api")
-
-    return webClient
-      .get()
-      .uri(uri)
-      .retrieve()
-      .bodyToMono(object : ParameterizedTypeReference<List<GlobalContactRestrictionDto>>() {})
-      .onErrorResume { e ->
-        if (!clientUtils.isNotFoundError(e)) {
-          logger.error("get contact's global restrictions returned an error for get request $uri")
-          Mono.error(e)
-        } else {
-          logger.error("get contact's global restrictions returned NOT_FOUND for get request $uri")
-          Mono.error { PersonNotFoundException("Contact with id $contactId not found", cause = e) }
-        }
-      }
-      .blockOptional(apiTimeout).orElseThrow { IllegalStateException("Timeout getting a contact's global restrictions for uri $uri on personal-relationships-api") }
-  }
-
   /**
    * Builds ContactDto entries from Personal Relationships API data to preserve the contract we have with calling APIs.
    *
@@ -174,7 +200,7 @@ class PersonalRelationshipsApiClient(
    * Returns:
    * - A ContactDto list [to keep the exact structure as the previous client prison-api had]
    */
-  private fun convertToContactDto(prisonerContactsList: List<PersonalRelationshipsContactDto>, prisonerContactRestrictions: PrisonerContactRestrictionsResponseDto?): List<ContactDto> {
+  private fun convertToContactDto(prisonerContactsList: List<PersonalRelationshipsPrisonerContactDto>, prisonerContactRestrictions: PrisonerContactRestrictionsResponseDto?): List<PrisonerContactDto> {
     // 1) Index LOCAL restrictions by prisonerContactId (relationship-level)
     val localByPrisonerContactId: Map<Long, List<RestrictionDto>> = if (prisonerContactRestrictions != null) {
       prisonerContactRestrictions.prisonerContactRestrictions
@@ -213,7 +239,7 @@ class PersonalRelationshipsApiClient(
       val local = localByPrisonerContactId[c.prisonerContactId].orEmpty()
       val global = globalByContactId[c.contactId].orEmpty()
 
-      ContactDto(personalRelationshipsContact = c, restrictions = local + global)
+      PrisonerContactDto(personalRelationshipsPrisonerContact = c, restrictions = local + global)
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/ContactsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/ContactsController.kt
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.ContactDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.RestrictionDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.service.ContactsService
 
@@ -28,6 +29,48 @@ class ContactsController(
 ) {
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  @PreAuthorize("hasRole('PRISONER_CONTACT_REGISTRY')")
+  @GetMapping(CONTACTS_CONTROLLER_PATH)
+  @Operation(
+    summary = "Get a contact's global restrictions",
+    description = "Returns a contact's global restrictions",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Contact's global restrictions returned",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Incorrect request to retrieve a contact's global restrictions",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Incorrect permissions to retrieve a contact's global restrictions",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Contact not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun getContact(
+    @Schema(description = "The ID of the contact whose global restrictions are sought.", example = "57392371")
+    @PathVariable
+    contactId: Long,
+  ): ContactDto {
+    log.debug("getContact called with contactId: {}", contactId)
+
+    return contactsService.getContactByContactId(contactId)
   }
 
   @PreAuthorize("hasRole('PRISONER_CONTACT_REGISTRY')")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/ContactsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/ContactsController.kt
@@ -34,16 +34,16 @@ class ContactsController(
   @PreAuthorize("hasRole('PRISONER_CONTACT_REGISTRY')")
   @GetMapping(CONTACTS_CONTROLLER_PATH)
   @Operation(
-    summary = "Get a contact's global restrictions",
-    description = "Returns a contact's global restrictions",
+    summary = "Get a contact via Contact ID",
+    description = "Returns a contact's basic details",
     responses = [
       ApiResponse(
         responseCode = "200",
-        description = "Contact's global restrictions returned",
+        description = "Contact's basic details returned",
       ),
       ApiResponse(
         responseCode = "400",
-        description = "Incorrect request to retrieve a contact's global restrictions",
+        description = "Incorrect request to retrieve a contact's details",
         content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
       ),
       ApiResponse(
@@ -53,7 +53,7 @@ class ContactsController(
       ),
       ApiResponse(
         responseCode = "403",
-        description = "Incorrect permissions to retrieve a contact's global restrictions",
+        description = "Incorrect permissions to retrieve a contact's details",
         content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
       ),
       ApiResponse(
@@ -64,7 +64,7 @@ class ContactsController(
     ],
   )
   fun getContact(
-    @Schema(description = "The ID of the contact whose global restrictions are sought.", example = "57392371")
+    @Schema(description = "The ID of the contact", example = "57392371")
     @PathVariable
     contactId: Long,
   ): ContactDto {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/PrisonerContactControllerV2.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/PrisonerContactControllerV2.kt
@@ -19,9 +19,9 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.config.ErrorResponse
-import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.ContactDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.DateRangeDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.HasClosedRestrictionDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.PrisonerContactDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.visit.scheduler.RequestVisitVisitorRestrictionsBodyDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.service.PrisonerContactRegistryServiceV2
 import java.time.LocalDate
@@ -87,7 +87,7 @@ class PrisonerContactControllerV2(
     @RequestParam(value = "withRestrictions", required = false)
     @Parameter(description = "Defaults to false. Returns all contacts restrictions if set to true, skips grabbing restrictions if false", example = "false")
     withRestrictions: Boolean? = false,
-  ): List<ContactDto> {
+  ): List<PrisonerContactDto> {
     log.debug("getPrisonerSocialContacts called with params : Prisoner: {}, hasDateOfBirth = {}, withRestrictions = {}", prisonerId, hasDateOfBirth, withRestrictions)
 
     return contactService.getSocialContactList(
@@ -140,7 +140,7 @@ class PrisonerContactControllerV2(
     @RequestParam(value = "withRestrictions", required = false)
     @Parameter(description = "Defaults to false. Returns all contacts restrictions if set to true, skips grabbing restrictions if false", example = "false")
     withRestrictions: Boolean? = false,
-  ): List<ContactDto> {
+  ): List<PrisonerContactDto> {
     log.debug("getPrisonersSocialContactsApproved called with params : Prisoner: {}, hasDateOfBirth = {}, withRestrictions = {}", prisonerId, hasDateOfBirth, withRestrictions)
 
     return contactService.getSocialContactList(
@@ -337,7 +337,7 @@ class PrisonerContactControllerV2(
     @RequestParam(value = "withRestrictions", required = false)
     @Parameter(description = "Defaults to false. Returns contact restrictions if set to true, skips grabbing restrictions if false", example = "false")
     withRestrictions: Boolean? = false,
-  ): ContactDto = contactService.getPrisonerContactViaRelationship(
+  ): PrisonerContactDto = contactService.getPrisonerContactViaRelationship(
     prisonerId,
     contactId,
     relationshipId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/AddressDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/AddressDto.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.prisonercontactregistry.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
-import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PersonalRelationshipsContactDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PersonalRelationshipsPrisonerContactDto
 
 @Schema(description = "An address")
 class AddressDto(
@@ -28,17 +28,17 @@ class AddressDto(
   @param:Schema(description = "No Fixed Address", example = "N", required = true)
   val noFixedAddress: Boolean,
 ) {
-  constructor(personalRelationshipsContactDto: PersonalRelationshipsContactDto) : this(
-    flat = personalRelationshipsContactDto.flat,
-    premise = personalRelationshipsContactDto.property,
-    street = personalRelationshipsContactDto.street,
-    locality = personalRelationshipsContactDto.area,
-    town = personalRelationshipsContactDto.cityDescription,
-    postalCode = personalRelationshipsContactDto.postcode,
-    county = personalRelationshipsContactDto.countyDescription,
-    country = personalRelationshipsContactDto.countryDescription,
-    comment = personalRelationshipsContactDto.comments,
-    primary = personalRelationshipsContactDto.primaryAddress ?: false,
-    noFixedAddress = personalRelationshipsContactDto.noFixedAddress ?: false,
+  constructor(personalRelationshipsPrisonerContactDto: PersonalRelationshipsPrisonerContactDto) : this(
+    flat = personalRelationshipsPrisonerContactDto.flat,
+    premise = personalRelationshipsPrisonerContactDto.property,
+    street = personalRelationshipsPrisonerContactDto.street,
+    locality = personalRelationshipsPrisonerContactDto.area,
+    town = personalRelationshipsPrisonerContactDto.cityDescription,
+    postalCode = personalRelationshipsPrisonerContactDto.postcode,
+    county = personalRelationshipsPrisonerContactDto.countyDescription,
+    country = personalRelationshipsPrisonerContactDto.countryDescription,
+    comment = personalRelationshipsPrisonerContactDto.comments,
+    primary = personalRelationshipsPrisonerContactDto.primaryAddress ?: false,
+    noFixedAddress = personalRelationshipsPrisonerContactDto.noFixedAddress ?: false,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/ContactDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/ContactDto.kt
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PersonalRelationshipsContactDto
 import java.time.LocalDate
 
-@Schema(description = "A contact for a prisoner")
+@Schema(description = "A contact (no prisoner relationship)")
 data class ContactDto(
   @param:Schema(description = "Identifier for this contact", example = "5871791")
   val contactId: Long? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/ContactDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/ContactDto.kt
@@ -6,8 +6,8 @@ import java.time.LocalDate
 
 @Schema(description = "A contact for a prisoner")
 data class ContactDto(
-  @param:Schema(description = "Identifier for this contact (Person in NOMIS)", example = "5871791")
-  val personId: Long? = null,
+  @param:Schema(description = "Identifier for this contact", example = "5871791")
+  val contactId: Long? = null,
   @param:Schema(description = "First name", example = "John", required = true)
   val firstName: String,
   @param:Schema(description = "Middle name", example = "Mark", required = false)
@@ -16,43 +16,13 @@ data class ContactDto(
   val lastName: String,
   @param:Schema(description = "Date of birth", example = "1980-01-28", required = false)
   val dateOfBirth: LocalDate? = null,
-  @param:Schema(description = "Code for relationship to Prisoner", example = "RO", required = true)
-  val relationshipCode: String,
-  @param:Schema(description = "Description of relationship to Prisoner", example = "Responsible Officer", required = false)
-  val relationshipDescription: String? = null,
-  @param:Schema(description = "Type of Contact", example = "O", required = true)
-  val contactType: String,
-  @param:Schema(description = "Description of Contact Type", example = "Official", required = false)
-  val contactTypeDescription: String? = null,
-  @param:Schema(description = "Approved Visitor Flag", required = true)
-  val approvedVisitor: Boolean,
-  @param:Schema(description = "Emergency Contact Flag", required = true)
-  val emergencyContact: Boolean,
-  @param:Schema(description = "Next of Kin Flag", required = true)
-  val nextOfKin: Boolean,
-  @param:Schema(description = "List of restrictions associated with the contact", required = false)
-  val restrictions: List<RestrictionDto> = listOf(),
-  @param:Schema(description = "Address associated with the contact", required = false)
-  val address: AddressDto? = null,
-  @param:Schema(description = "Additional Information", example = "This is a comment text", required = false)
-  val commentText: String? = null,
 ) {
-  constructor(personalRelationshipsContact: PersonalRelationshipsContactDto, restrictions: List<RestrictionDto>) : this(
-    personId = personalRelationshipsContact.contactId,
+  constructor(personalRelationshipsContact: PersonalRelationshipsContactDto) : this(
+    contactId = personalRelationshipsContact.id,
     firstName = personalRelationshipsContact.firstName.toNormalCase()!!,
     middleName = personalRelationshipsContact.middleNames.toNormalCase(),
     lastName = personalRelationshipsContact.lastName.toNormalCase()!!,
     dateOfBirth = personalRelationshipsContact.dateOfBirth,
-    relationshipCode = personalRelationshipsContact.relationshipToPrisonerCode,
-    relationshipDescription = personalRelationshipsContact.relationshipToPrisonerDescription,
-    contactType = personalRelationshipsContact.relationshipTypeCode,
-    contactTypeDescription = personalRelationshipsContact.relationshipTypeDescription,
-    approvedVisitor = personalRelationshipsContact.isApprovedVisitor,
-    emergencyContact = personalRelationshipsContact.isEmergencyContact,
-    nextOfKin = personalRelationshipsContact.isNextOfKin,
-    restrictions = restrictions,
-    address = AddressDto(personalRelationshipsContact),
-    commentText = personalRelationshipsContact.comments,
   )
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/ContactsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/ContactsDto.kt
@@ -1,5 +1,5 @@
 package uk.gov.justice.digital.hmpps.prisonercontactregistry.dto
 
 data class ContactsDto(
-  var offenderContacts: List<ContactDto> = listOf(),
+  var offenderContacts: List<PrisonerContactDto> = listOf(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/PrisonerContactDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/PrisonerContactDto.kt
@@ -1,0 +1,64 @@
+package uk.gov.justice.digital.hmpps.prisonercontactregistry.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PersonalRelationshipsPrisonerContactDto
+import java.time.LocalDate
+
+@Schema(description = "A contact for a prisoner")
+data class PrisonerContactDto(
+  @param:Schema(description = "Identifier for this contact (Person in NOMIS)", example = "5871791")
+  val personId: Long? = null,
+  @param:Schema(description = "First name", example = "John", required = true)
+  val firstName: String,
+  @param:Schema(description = "Middle name", example = "Mark", required = false)
+  val middleName: String? = null,
+  @param:Schema(description = "Last name", example = "Smith", required = true)
+  val lastName: String,
+  @param:Schema(description = "Date of birth", example = "1980-01-28", required = false)
+  val dateOfBirth: LocalDate? = null,
+  @param:Schema(description = "Code for relationship to Prisoner", example = "RO", required = true)
+  val relationshipCode: String,
+  @param:Schema(description = "Description of relationship to Prisoner", example = "Responsible Officer", required = false)
+  val relationshipDescription: String? = null,
+  @param:Schema(description = "Type of Contact", example = "O", required = true)
+  val contactType: String,
+  @param:Schema(description = "Description of Contact Type", example = "Official", required = false)
+  val contactTypeDescription: String? = null,
+  @param:Schema(description = "Approved Visitor Flag", required = true)
+  val approvedVisitor: Boolean,
+  @param:Schema(description = "Emergency Contact Flag", required = true)
+  val emergencyContact: Boolean,
+  @param:Schema(description = "Next of Kin Flag", required = true)
+  val nextOfKin: Boolean,
+  @param:Schema(description = "List of restrictions associated with the contact", required = false)
+  val restrictions: List<RestrictionDto> = listOf(),
+  @param:Schema(description = "Address associated with the contact", required = false)
+  val address: AddressDto? = null,
+  @param:Schema(description = "Additional Information", example = "This is a comment text", required = false)
+  val commentText: String? = null,
+) {
+  constructor(personalRelationshipsPrisonerContact: PersonalRelationshipsPrisonerContactDto, restrictions: List<RestrictionDto>) : this(
+    personId = personalRelationshipsPrisonerContact.contactId,
+    firstName = personalRelationshipsPrisonerContact.firstName.toNormalCase()!!,
+    middleName = personalRelationshipsPrisonerContact.middleNames.toNormalCase(),
+    lastName = personalRelationshipsPrisonerContact.lastName.toNormalCase()!!,
+    dateOfBirth = personalRelationshipsPrisonerContact.dateOfBirth,
+    relationshipCode = personalRelationshipsPrisonerContact.relationshipToPrisonerCode,
+    relationshipDescription = personalRelationshipsPrisonerContact.relationshipToPrisonerDescription,
+    contactType = personalRelationshipsPrisonerContact.relationshipTypeCode,
+    contactTypeDescription = personalRelationshipsPrisonerContact.relationshipTypeDescription,
+    approvedVisitor = personalRelationshipsPrisonerContact.isApprovedVisitor,
+    emergencyContact = personalRelationshipsPrisonerContact.isEmergencyContact,
+    nextOfKin = personalRelationshipsPrisonerContact.isNextOfKin,
+    restrictions = restrictions,
+    address = AddressDto(personalRelationshipsPrisonerContact),
+    commentText = personalRelationshipsPrisonerContact.comments,
+  )
+}
+
+private fun String?.toNormalCase(): String? = this
+  ?.lowercase()
+  ?.split(" ")
+  ?.joinToString(" ") { word ->
+    word.replaceFirstChar { it.uppercase() }
+  }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/personal/relationships/PersonalRelationshipsContactDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/personal/relationships/PersonalRelationshipsContactDto.kt
@@ -4,75 +4,19 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 
 data class PersonalRelationshipsContactDto(
-  @param:Schema(description = "Identifier for this contact", example = "5871791")
-  val contactId: Long,
 
-  @param:Schema(description = "Identifier for the prisoner / contact relationship", example = "5871791")
-  val prisonerContactId: Long,
+  @param:Schema(description = "The id of the contact", example = "123456")
+  val id: Long,
 
-  @param:Schema(description = "First name", example = "John", required = true)
+  @param:Schema(description = "The first name of the contact", example = "John")
   val firstName: String,
 
-  @param:Schema(description = "Middle names", example = "William", required = false)
+  @param:Schema(description = "The middle name of the contact, if any", example = "William", nullable = true)
   val middleNames: String? = null,
 
-  @param:Schema(description = "Last name", example = "Smith", required = true)
+  @param:Schema(description = "The last name of the contact", example = "Doe")
   val lastName: String,
 
-  @param:Schema(description = "Date of birth", example = "1980-01-28", required = false)
+  @param:Schema(description = "The date of birth of the contact, if known", example = "1980-01-01", nullable = true)
   val dateOfBirth: LocalDate? = null,
-
-  @param:Schema(description = "Code for relationship to Prisoner", example = "FRI", required = true)
-  val relationshipToPrisonerCode: String,
-
-  @param:Schema(description = "Description of relationship to Prisoner", example = "Friend", required = false)
-  val relationshipToPrisonerDescription: String? = null,
-
-  @param:Schema(description = "Relationship type code", example = "S", required = true)
-  val relationshipTypeCode: String,
-
-  @param:Schema(description = "Relationship type description", example = "Friend", required = false)
-  val relationshipTypeDescription: String? = null,
-
-  @param:Schema(description = "Approved Visitor Flag", required = true)
-  val isApprovedVisitor: Boolean,
-
-  @param:Schema(description = "Emergency Contact Flag", required = true)
-  val isEmergencyContact: Boolean,
-
-  @param:Schema(description = "Next of Kin Flag", required = true)
-  val isNextOfKin: Boolean,
-
-  @param:Schema(description = "Additional Information", example = "This is a comment text", required = false)
-  val comments: String? = null,
-
-  @param:Schema(description = "Flat", example = "Flat 1", required = false)
-  val flat: String? = null,
-
-  @param:Schema(description = "Property", example = "123", required = false)
-  val property: String? = null,
-
-  @param:Schema(description = "Street", example = "Baker Street", required = false)
-  val street: String? = null,
-
-  @param:Schema(description = "Area", example = "Marylebone", required = false)
-  val area: String? = null,
-
-  @param:Schema(description = "City description", example = "Sheffield", required = false)
-  val cityDescription: String? = null,
-
-  @param:Schema(description = "County description", example = "South Yorkshire", required = false)
-  val countyDescription: String? = null,
-
-  @param:Schema(description = "Postcode", example = "NW1 6XE", required = false)
-  val postcode: String? = null,
-
-  @param:Schema(description = "Country description", example = "England", required = false)
-  val countryDescription: String? = null,
-
-  @param:Schema(description = "No Fixed Address", example = "false", required = false)
-  val noFixedAddress: Boolean? = null,
-
-  @param:Schema(description = "Primary Address", example = "true", required = false)
-  val primaryAddress: Boolean? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/personal/relationships/PersonalRelationshipsPrisonerContactDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/personal/relationships/PersonalRelationshipsPrisonerContactDto.kt
@@ -1,0 +1,78 @@
+package uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+data class PersonalRelationshipsPrisonerContactDto(
+  @param:Schema(description = "Identifier for this contact", example = "5871791")
+  val contactId: Long,
+
+  @param:Schema(description = "Identifier for the prisoner / contact relationship", example = "5871791")
+  val prisonerContactId: Long,
+
+  @param:Schema(description = "First name", example = "John", required = true)
+  val firstName: String,
+
+  @param:Schema(description = "Middle names", example = "William", required = false)
+  val middleNames: String? = null,
+
+  @param:Schema(description = "Last name", example = "Smith", required = true)
+  val lastName: String,
+
+  @param:Schema(description = "Date of birth", example = "1980-01-28", required = false)
+  val dateOfBirth: LocalDate? = null,
+
+  @param:Schema(description = "Code for relationship to Prisoner", example = "FRI", required = true)
+  val relationshipToPrisonerCode: String,
+
+  @param:Schema(description = "Description of relationship to Prisoner", example = "Friend", required = false)
+  val relationshipToPrisonerDescription: String? = null,
+
+  @param:Schema(description = "Relationship type code", example = "S", required = true)
+  val relationshipTypeCode: String,
+
+  @param:Schema(description = "Relationship type description", example = "Friend", required = false)
+  val relationshipTypeDescription: String? = null,
+
+  @param:Schema(description = "Approved Visitor Flag", required = true)
+  val isApprovedVisitor: Boolean,
+
+  @param:Schema(description = "Emergency Contact Flag", required = true)
+  val isEmergencyContact: Boolean,
+
+  @param:Schema(description = "Next of Kin Flag", required = true)
+  val isNextOfKin: Boolean,
+
+  @param:Schema(description = "Additional Information", example = "This is a comment text", required = false)
+  val comments: String? = null,
+
+  @param:Schema(description = "Flat", example = "Flat 1", required = false)
+  val flat: String? = null,
+
+  @param:Schema(description = "Property", example = "123", required = false)
+  val property: String? = null,
+
+  @param:Schema(description = "Street", example = "Baker Street", required = false)
+  val street: String? = null,
+
+  @param:Schema(description = "Area", example = "Marylebone", required = false)
+  val area: String? = null,
+
+  @param:Schema(description = "City description", example = "Sheffield", required = false)
+  val cityDescription: String? = null,
+
+  @param:Schema(description = "County description", example = "South Yorkshire", required = false)
+  val countyDescription: String? = null,
+
+  @param:Schema(description = "Postcode", example = "NW1 6XE", required = false)
+  val postcode: String? = null,
+
+  @param:Schema(description = "Country description", example = "England", required = false)
+  val countryDescription: String? = null,
+
+  @param:Schema(description = "No Fixed Address", example = "false", required = false)
+  val noFixedAddress: Boolean? = null,
+
+  @param:Schema(description = "Primary Address", example = "true", required = false)
+  val primaryAddress: Boolean? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/service/ContactsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/service/ContactsService.kt
@@ -4,12 +4,18 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.client.PersonalRelationshipsApiClient
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.ContactDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.RestrictionDto
 
 @Service
 class ContactsService(private val personalRelationshipsApiClient: PersonalRelationshipsApiClient) {
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun getContactByContactId(contactId: Long): ContactDto {
+    PrisonerContactRegistryServiceV2.Companion.log.debug("getContactByContactId called with parameters : contactId - {}", contactId)
+    return personalRelationshipsApiClient.getContact(contactId)
   }
 
   fun getContactGlobalRestrictions(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/service/PrisonerContactRegistryServiceV2.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/service/PrisonerContactRegistryServiceV2.kt
@@ -4,9 +4,9 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.client.PersonalRelationshipsApiClient
-import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.ContactDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.DateRangeDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.HasClosedRestrictionDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.PrisonerContactDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.RestrictionDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.visit.scheduler.RequestVisitVisitorRestrictionsBodyDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.enum.RestrictionType
@@ -25,7 +25,7 @@ class PrisonerContactRegistryServiceV2(private val personalRelationshipsApiClien
     hasDateOfBirth: Boolean,
     approvedContactsOnly: Boolean,
     withRestrictions: Boolean,
-  ): List<ContactDto> {
+  ): List<PrisonerContactDto> {
     log.debug("getSocialContactList called with parameters : prisonerId - {}, hasDateOfBirth - {}, approvedContactsOnly - {}", prisonerId, hasDateOfBirth, approvedContactsOnly)
 
     var socialContacts = getContactsByPrisonerId(prisonerId, approvedContactsOnly, withRestrictions)
@@ -132,7 +132,7 @@ class PrisonerContactRegistryServiceV2(private val personalRelationshipsApiClien
     contactId: String,
     relationshipId: Long,
     withRestrictions: Boolean,
-  ): ContactDto {
+  ): PrisonerContactDto {
     log.info("getPrisonerContactViaRelationship called with parameters : prisonerId $prisonerId, contactId $contactId, relationshipId $relationshipId")
 
     val contact = personalRelationshipsApiClient.getPrisonerContactViaRelationshipId(prisonerId, contactId, relationshipId, withRestrictions)
@@ -156,7 +156,7 @@ class PrisonerContactRegistryServiceV2(private val personalRelationshipsApiClien
       .filter { it.restrictionType == restrictionType.toString() }
   }
 
-  private fun getContactsByPrisonerId(prisonerId: String, approvedContactsOnly: Boolean, withRestrictions: Boolean): List<ContactDto> = personalRelationshipsApiClient.getPrisonerContacts(prisonerId, approvedContactsOnly, withRestrictions)
+  private fun getContactsByPrisonerId(prisonerId: String, approvedContactsOnly: Boolean, withRestrictions: Boolean): List<PrisonerContactDto> = personalRelationshipsApiClient.getPrisonerContacts(prisonerId, approvedContactsOnly, withRestrictions)
 
-  private final fun getDefaultSortOrder(): Comparator<ContactDto> = compareBy({ it.lastName }, { it.firstName })
+  private final fun getDefaultSortOrder(): Comparator<PrisonerContactDto> = compareBy({ it.lastName }, { it.firstName })
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/IntegrationTestBase.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.prisonercontactregistry.client.PersonalRelat
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.AddressDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.GlobalContactRestrictionDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PersonalRelationshipsContactDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PersonalRelationshipsPrisonerContactDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PrisonerContactRestrictionDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.helper.JwtAuthHelper
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.integration.mock.HmppsAuthExtension
@@ -78,17 +79,31 @@ abstract class IntegrationTestBase {
     assertThat(contactAddress.noFixedAddress).isFalse()
   }
 
-  fun createPersonalRelationshipsContactDtoList(
+  fun createPersonalRelationshipsContactDto(
+    contactId: Long,
+    firstName: String = "test",
+    middleNames: String = "middle",
+    lastName: String = "user",
+    dateOfBirth: LocalDate = LocalDate.of(1980, 9, 13),
+  ): PersonalRelationshipsContactDto = PersonalRelationshipsContactDto(
+    id = contactId,
+    firstName = firstName,
+    middleNames = middleNames,
+    lastName = lastName,
+    dateOfBirth = dateOfBirth,
+  )
+
+  fun createPersonalRelationshipsPrisonerContactDtoList(
     contactIds: List<Long>,
     prisonerContactIds: List<Long>,
     isApproved: Boolean = true,
-  ): List<PersonalRelationshipsContactDto> {
+  ): List<PersonalRelationshipsPrisonerContactDto> {
     require(contactIds.size == prisonerContactIds.size) {
       "contactIds and prisonerContactIds must be the same size"
     }
 
     return contactIds.mapIndexed { index, contactId ->
-      PersonalRelationshipsContactDto(
+      PersonalRelationshipsPrisonerContactDto(
         contactId = contactId,
         prisonerContactId = prisonerContactIds[index],
         firstName = "test",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/contact/GetContactTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/contact/GetContactTest.kt
@@ -1,0 +1,93 @@
+package uk.gov.justice.digital.hmpps.prisonercontactregistry.integration.contact
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.springframework.http.HttpStatus
+import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.controller.CONTACTS_CONTROLLER_PATH
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.ContactDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.integration.TestObjectMapper
+
+@Suppress("ClassName")
+@DisplayName("ContactsController - Get Contact - $CONTACTS_CONTROLLER_PATH")
+class GetContactTest : IntegrationTestBase() {
+  @Nested
+  inner class authentication {
+    @Test
+    fun `requires authentication`() {
+      val contactId = 2187525L
+
+      webTestClient.get().uri(CONTACTS_CONTROLLER_PATH.replace("{contactId}", contactId.toString()))
+        .exchange()
+        .expectStatus().isUnauthorized
+    }
+
+    @Test
+    fun `requires correct role`() {
+      val contactId = 2187525L
+
+      webTestClient.get().uri(CONTACTS_CONTROLLER_PATH.replace("{contactId}", contactId.toString()))
+        .headers(setAuthorisation(roles = listOf("AnyThingWillDo")))
+        .exchange()
+        .expectStatus().isForbidden
+        .expectBody()
+        .jsonPath("userMessage").isEqualTo("Access denied")
+    }
+  }
+
+  @Test
+  fun `when call to get contact is made then contact is returned`() {
+    val contactId = 2187525L
+
+    personalRelationshipsApiMockServer.stubGetContact(contactId, createPersonalRelationshipsContactDto(contactId = contactId))
+
+    val returnResult = callGetContact(contactId)
+      .expectStatus().isOk
+      .expectBody()
+
+    val contact = getResults(returnResult)
+    assertThat(contact.contactId).isEqualTo(contactId)
+
+    verify(personalRelationshipsApiClientSpy, times(1)).getContact(contactId)
+  }
+
+  @Test
+  fun `when personal relationship API get contact call fails with BAD_REQUEST then entire call fails`() {
+    val contactId = 2187525L
+
+    personalRelationshipsApiMockServer.stubGetContact(contactId, null, HttpStatus.BAD_REQUEST)
+
+    callGetContact(contactId)
+      .expectStatus().isBadRequest
+      .expectBody()
+  }
+
+  @Test
+  fun `when personal relationship API get contact call fails with NOT_FOUND then entire call fails`() {
+    val contactId = 2187525L
+
+    personalRelationshipsApiMockServer.stubGetContact(contactId, null, HttpStatus.NOT_FOUND)
+
+    callGetContact(contactId)
+      .expectStatus().isNotFound
+      .expectBody()
+  }
+
+  private fun getResults(returnResult: WebTestClient.BodyContentSpec): ContactDto = TestObjectMapper.mapper.readValue(returnResult.returnResult().responseBody, ContactDto::class.java)
+
+  private fun callGetContact(
+    contactId: Long,
+  ): WebTestClient.ResponseSpec {
+    val uri = CONTACTS_CONTROLLER_PATH.replace("{contactId}", contactId.toString())
+    return webTestClient
+      .get()
+      .uri(uri)
+      .headers(setAuthorisation(roles = listOf("ROLE_PRISONER_CONTACT_REGISTRY")))
+      .exchange()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/mock/PersonalRelationshipsApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/mock/PersonalRelationshipsApiMockServer.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.prisonercontactregistry.client.PageMetadata
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.client.PagedResponse
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.GlobalContactRestrictionDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PersonalRelationshipsContactDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PersonalRelationshipsPrisonerContactDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PrisonerContactIdsRequestDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PrisonerContactRestrictionsDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PrisonerContactRestrictionsResponseDto
@@ -24,7 +25,7 @@ class PersonalRelationshipsApiMockServer : WireMockServer(8093) {
   fun stubGetPrisonerContactViaRelationshipId(
     prisonerId: String,
     contactId: Long,
-    relationships: List<PersonalRelationshipsContactDto>? = null,
+    relationships: List<PersonalRelationshipsPrisonerContactDto>? = null,
     httpStatus: HttpStatus = HttpStatus.OK,
   ) {
     val uri = "/prisoner/$prisonerId/contact/$contactId"
@@ -43,7 +44,7 @@ class PersonalRelationshipsApiMockServer : WireMockServer(8093) {
 
   fun stubGetAllContacts(
     prisonerId: String,
-    contacts: List<PersonalRelationshipsContactDto>? = null,
+    contacts: List<PersonalRelationshipsPrisonerContactDto>? = null,
     approvedVisitorOnly: Boolean = false,
     page: Int = 0,
     size: Int = 400,
@@ -133,6 +134,25 @@ class PersonalRelationshipsApiMockServer : WireMockServer(8093) {
         .withStatus(HttpStatus.OK.value())
         .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
         .withBody(TestObjectMapper.mapper.writeValueAsString(restrictions))
+    }
+
+    stubFor(get(urlPathEqualTo(uri)).willReturn(response))
+  }
+
+  fun stubGetContact(
+    contactId: Long,
+    contact: PersonalRelationshipsContactDto? = null,
+    httpStatus: HttpStatus = HttpStatus.NOT_FOUND,
+  ) {
+    val uri = "/contact/$contactId"
+
+    val response = if (contact == null) {
+      aResponse().withStatus(httpStatus.value())
+    } else {
+      aResponse()
+        .withStatus(HttpStatus.OK.value())
+        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        .withBody(TestObjectMapper.mapper.writeValueAsString(contact))
     }
 
     stubFor(get(urlPathEqualTo(uri)).willReturn(response))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/v2/GetDateRangeVisitorBannedRestrictionTypeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/v2/GetDateRangeVisitorBannedRestrictionTypeTest.kt
@@ -64,7 +64,7 @@ class GetDateRangeVisitorBannedRestrictionTypeTest : IntegrationTestBase() {
       val uri = createDateRangeBanUri(prisonerId, visitorIdsString, fromDate, toDate)
 
       val prisonerContactIds = listOf(999001L)
-      val prContacts = createPersonalRelationshipsContactDtoList(
+      val prContacts = createPersonalRelationshipsPrisonerContactDtoList(
         contactIds = listOf(2187525L),
         prisonerContactIds = prisonerContactIds,
         isApproved = true,
@@ -119,7 +119,7 @@ class GetDateRangeVisitorBannedRestrictionTypeTest : IntegrationTestBase() {
     val uri = createDateRangeBanUri(prisonerId, visitorIdsString, fromDate, toDate)
 
     val prisonerContactIds = listOf(999001L)
-    val prContacts = createPersonalRelationshipsContactDtoList(
+    val prContacts = createPersonalRelationshipsPrisonerContactDtoList(
       contactIds = listOf(2187524L),
       prisonerContactIds = prisonerContactIds,
       isApproved = true,
@@ -160,7 +160,7 @@ class GetDateRangeVisitorBannedRestrictionTypeTest : IntegrationTestBase() {
     val uri = createDateRangeBanUri(prisonerId, visitorIdsString, fromDate, toDate)
 
     val prisonerContactIds = listOf(999001L, 999002L)
-    val prContacts = createPersonalRelationshipsContactDtoList(
+    val prContacts = createPersonalRelationshipsPrisonerContactDtoList(
       contactIds = visitorIds,
       prisonerContactIds = prisonerContactIds,
       isApproved = true,
@@ -239,7 +239,7 @@ class GetDateRangeVisitorBannedRestrictionTypeTest : IntegrationTestBase() {
     val uri = createDateRangeBanUri(prisonerId, visitorIdsString, fromDate, toDate)
 
     val prisonerContactIds = listOf(999001L)
-    val prContacts = createPersonalRelationshipsContactDtoList(
+    val prContacts = createPersonalRelationshipsPrisonerContactDtoList(
       contactIds = visitorIds,
       prisonerContactIds = prisonerContactIds,
       isApproved = true,
@@ -302,7 +302,7 @@ class GetDateRangeVisitorBannedRestrictionTypeTest : IntegrationTestBase() {
     val uri = createDateRangeBanUri(prisonerId, visitorIdsString, fromDate, toDate)
 
     val prisonerContactIds = listOf(999001L)
-    val prContacts = createPersonalRelationshipsContactDtoList(
+    val prContacts = createPersonalRelationshipsPrisonerContactDtoList(
       contactIds = visitorIds,
       prisonerContactIds = prisonerContactIds,
       isApproved = true,
@@ -365,7 +365,7 @@ class GetDateRangeVisitorBannedRestrictionTypeTest : IntegrationTestBase() {
     val uri = createDateRangeBanUri(prisonerId, visitorIdsString, fromDate, toDate)
 
     val prisonerContactIds = listOf(999001L)
-    val prContacts = createPersonalRelationshipsContactDtoList(
+    val prContacts = createPersonalRelationshipsPrisonerContactDtoList(
       contactIds = visitorIds,
       prisonerContactIds = prisonerContactIds,
       isApproved = true,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/v2/GetDateRangeVisitorRestrictionsWhichEffectRequestVisitsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/v2/GetDateRangeVisitorRestrictionsWhichEffectRequestVisitsTest.kt
@@ -57,7 +57,7 @@ class GetDateRangeVisitorRestrictionsWhichEffectRequestVisitsTest : IntegrationT
       )
 
       val prisonerContactIds = listOf(999001L)
-      val prContacts = createPersonalRelationshipsContactDtoList(
+      val prContacts = createPersonalRelationshipsPrisonerContactDtoList(
         contactIds = listOf(2187525L),
         prisonerContactIds = prisonerContactIds,
         isApproved = true,
@@ -111,7 +111,7 @@ class GetDateRangeVisitorRestrictionsWhichEffectRequestVisitsTest : IntegrationT
     )
 
     val prisonerContactIds = listOf(999001L)
-    val prContacts = createPersonalRelationshipsContactDtoList(
+    val prContacts = createPersonalRelationshipsPrisonerContactDtoList(
       contactIds = listOf(2187524L),
       prisonerContactIds = prisonerContactIds,
       isApproved = true,
@@ -151,7 +151,7 @@ class GetDateRangeVisitorRestrictionsWhichEffectRequestVisitsTest : IntegrationT
     )
 
     val prisonerContactIds = listOf(999001L, 999002L)
-    val prContacts = createPersonalRelationshipsContactDtoList(
+    val prContacts = createPersonalRelationshipsPrisonerContactDtoList(
       contactIds = listOf(2187524L, 2187525L),
       prisonerContactIds = prisonerContactIds,
       isApproved = true,
@@ -189,7 +189,7 @@ class GetDateRangeVisitorRestrictionsWhichEffectRequestVisitsTest : IntegrationT
     )
 
     val prisonerContactIds = listOf(999001L, 999002L)
-    val prContacts = createPersonalRelationshipsContactDtoList(
+    val prContacts = createPersonalRelationshipsPrisonerContactDtoList(
       contactIds = listOf(2187524L, 2187525L),
       prisonerContactIds = prisonerContactIds,
       isApproved = true,
@@ -266,7 +266,7 @@ class GetDateRangeVisitorRestrictionsWhichEffectRequestVisitsTest : IntegrationT
     )
 
     val prisonerContactIds = listOf(999001L, 999002L)
-    val prContacts = createPersonalRelationshipsContactDtoList(
+    val prContacts = createPersonalRelationshipsPrisonerContactDtoList(
       contactIds = listOf(2187524L, 2187525L),
       prisonerContactIds = prisonerContactIds,
       isApproved = true,
@@ -344,7 +344,7 @@ class GetDateRangeVisitorRestrictionsWhichEffectRequestVisitsTest : IntegrationT
     )
 
     val prisonerContactIds = listOf(999001L, 999002L)
-    val prContacts = createPersonalRelationshipsContactDtoList(
+    val prContacts = createPersonalRelationshipsPrisonerContactDtoList(
       contactIds = listOf(2187524L, 2187525L),
       prisonerContactIds = prisonerContactIds,
       isApproved = true,
@@ -425,7 +425,7 @@ class GetDateRangeVisitorRestrictionsWhichEffectRequestVisitsTest : IntegrationT
     )
 
     val prisonerContactIds = listOf(999001L, 999002L)
-    val prContacts = createPersonalRelationshipsContactDtoList(
+    val prContacts = createPersonalRelationshipsPrisonerContactDtoList(
       contactIds = listOf(2187524L, 2187525L),
       prisonerContactIds = prisonerContactIds,
       isApproved = true,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/v2/GetVisitorClosedRestrictionTypeStatusTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/v2/GetVisitorClosedRestrictionTypeStatusTest.kt
@@ -58,7 +58,7 @@ class GetVisitorClosedRestrictionTypeStatusTest : IntegrationTestBase() {
       val uri = createVisitorsClosedRestrictionUri(prisonerId, visitorIdsString)
 
       val prisonerContactIds = listOf(999001L)
-      val prContacts = createPersonalRelationshipsContactDtoList(
+      val prContacts = createPersonalRelationshipsPrisonerContactDtoList(
         contactIds = visitorIds,
         prisonerContactIds = prisonerContactIds,
         isApproved = true,
@@ -95,7 +95,7 @@ class GetVisitorClosedRestrictionTypeStatusTest : IntegrationTestBase() {
     val returnedContactIds = listOf(2187521L)
     val returnedPrisonerContactIds = listOf(999001L)
 
-    val prContacts = createPersonalRelationshipsContactDtoList(
+    val prContacts = createPersonalRelationshipsPrisonerContactDtoList(
       contactIds = returnedContactIds,
       prisonerContactIds = returnedPrisonerContactIds,
       isApproved = true,
@@ -135,7 +135,7 @@ class GetVisitorClosedRestrictionTypeStatusTest : IntegrationTestBase() {
     val visitorIdsString = visitorIds.joinToString(",")
     val uri = createVisitorsClosedRestrictionUri(prisonerId, visitorIdsString)
 
-    val prContacts = createPersonalRelationshipsContactDtoList(
+    val prContacts = createPersonalRelationshipsPrisonerContactDtoList(
       contactIds = visitorIds,
       prisonerContactIds = prisonerContactIds,
     )
@@ -188,7 +188,7 @@ class GetVisitorClosedRestrictionTypeStatusTest : IntegrationTestBase() {
     val visitorIdsString = visitorIds.joinToString(",")
     val uri = createVisitorsClosedRestrictionUri(prisonerId, visitorIdsString)
 
-    val prContacts = createPersonalRelationshipsContactDtoList(
+    val prContacts = createPersonalRelationshipsPrisonerContactDtoList(
       contactIds = visitorIds,
       prisonerContactIds = prisonerContactIds,
     )
@@ -241,7 +241,7 @@ class GetVisitorClosedRestrictionTypeStatusTest : IntegrationTestBase() {
     val visitorIdsString = visitorIds.joinToString(",")
     val uri = createVisitorsClosedRestrictionUri(prisonerId, visitorIdsString)
 
-    val prContacts = createPersonalRelationshipsContactDtoList(
+    val prContacts = createPersonalRelationshipsPrisonerContactDtoList(
       contactIds = visitorIds,
       prisonerContactIds = prisonerContactIds,
     )
@@ -294,7 +294,7 @@ class GetVisitorClosedRestrictionTypeStatusTest : IntegrationTestBase() {
     val visitorIdsString = visitorIds.joinToString(",")
     val uri = createVisitorsClosedRestrictionUri(prisonerId, visitorIdsString)
 
-    val prContacts = createPersonalRelationshipsContactDtoList(
+    val prContacts = createPersonalRelationshipsPrisonerContactDtoList(
       contactIds = visitorIds,
       prisonerContactIds = prisonerContactIds,
     )
@@ -347,7 +347,7 @@ class GetVisitorClosedRestrictionTypeStatusTest : IntegrationTestBase() {
     val visitorIdsString = visitorIds.joinToString(",")
     val uri = createVisitorsClosedRestrictionUri(prisonerId, visitorIdsString)
 
-    val prContacts = createPersonalRelationshipsContactDtoList(
+    val prContacts = createPersonalRelationshipsPrisonerContactDtoList(
       contactIds = visitorIds,
       prisonerContactIds = prisonerContactIds,
       isApproved = true,
@@ -385,7 +385,7 @@ class GetVisitorClosedRestrictionTypeStatusTest : IntegrationTestBase() {
     val duplicateContactIds = listOf(2187529L, 2187529L)
     val prisonerContactIds = listOf(999001L, 999002L)
 
-    val prContacts = createPersonalRelationshipsContactDtoList(
+    val prContacts = createPersonalRelationshipsPrisonerContactDtoList(
       contactIds = duplicateContactIds,
       prisonerContactIds = prisonerContactIds,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/v2/PrisonerGetApprovedSocialContactsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/v2/PrisonerGetApprovedSocialContactsTest.kt
@@ -11,8 +11,8 @@ import org.springframework.http.HttpStatusCode
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.controller.V2_PRISONER_GET_SOCIAL_CONTACTS_APPROVED_CONTROLLER_PATH
-import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.ContactDto
-import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PersonalRelationshipsContactDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.PrisonerContactDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PersonalRelationshipsPrisonerContactDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PrisonerContactRestrictionsDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PrisonerContactRestrictionsResponseDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.integration.IntegrationTestBase
@@ -54,7 +54,7 @@ class PrisonerGetApprovedSocialContactsTest : IntegrationTestBase() {
       val visitorIds: List<Long> = listOf(2187525L)
 
       val prisonerContactIds = listOf(999001L)
-      val prContacts = createPersonalRelationshipsContactDtoList(
+      val prContacts = createPersonalRelationshipsPrisonerContactDtoList(
         contactIds = visitorIds,
         prisonerContactIds = prisonerContactIds,
         isApproved = true,
@@ -86,17 +86,17 @@ class PrisonerGetApprovedSocialContactsTest : IntegrationTestBase() {
     val visitorIds: List<Long> = listOf(socialContactWithRestrictionId, socialContactWithExpiredRestrictionId)
     val prisonerContactIds = listOf(999001L, 999002L)
 
-    val prContacts = mutableListOf<PersonalRelationshipsContactDto>()
+    val prContacts = mutableListOf<PersonalRelationshipsPrisonerContactDto>()
 
     prContacts.addAll(
-      createPersonalRelationshipsContactDtoList(
+      createPersonalRelationshipsPrisonerContactDtoList(
         contactIds = visitorIds,
         prisonerContactIds = prisonerContactIds,
       ),
     )
 
     prContacts.add(
-      PersonalRelationshipsContactDto(
+      PersonalRelationshipsPrisonerContactDto(
         contactId = socialContactWithNoDOB,
         prisonerContactId = 999003L,
         firstName = "test",
@@ -188,17 +188,17 @@ class PrisonerGetApprovedSocialContactsTest : IntegrationTestBase() {
     val visitorIds: List<Long> = listOf(socialContactWithRestrictionId, socialContactWithExpiredRestrictionId)
     val prisonerContactIds = listOf(999001L, 999002L)
 
-    val prContacts = mutableListOf<PersonalRelationshipsContactDto>()
+    val prContacts = mutableListOf<PersonalRelationshipsPrisonerContactDto>()
 
     prContacts.addAll(
-      createPersonalRelationshipsContactDtoList(
+      createPersonalRelationshipsPrisonerContactDtoList(
         contactIds = visitorIds,
         prisonerContactIds = prisonerContactIds,
       ),
     )
 
     prContacts.add(
-      PersonalRelationshipsContactDto(
+      PersonalRelationshipsPrisonerContactDto(
         contactId = socialContactWithNoDOB,
         prisonerContactId = 999003L,
         firstName = "test",
@@ -290,17 +290,17 @@ class PrisonerGetApprovedSocialContactsTest : IntegrationTestBase() {
     val visitorIds: List<Long> = listOf(socialContactWithRestrictionId, socialContactWithExpiredRestrictionId)
     val prisonerContactIds = listOf(999001L, 999002L)
 
-    val prContacts = mutableListOf<PersonalRelationshipsContactDto>()
+    val prContacts = mutableListOf<PersonalRelationshipsPrisonerContactDto>()
 
     prContacts.addAll(
-      createPersonalRelationshipsContactDtoList(
+      createPersonalRelationshipsPrisonerContactDtoList(
         contactIds = visitorIds,
         prisonerContactIds = prisonerContactIds,
       ),
     )
 
     prContacts.add(
-      PersonalRelationshipsContactDto(
+      PersonalRelationshipsPrisonerContactDto(
         contactId = socialContactWithNoDOB,
         prisonerContactId = 999003L,
         firstName = "test",
@@ -394,7 +394,7 @@ class PrisonerGetApprovedSocialContactsTest : IntegrationTestBase() {
     val visitorIds: List<Long> = listOf(2187525L)
 
     val prisonerContactIds = listOf(999001L)
-    val prContacts = createPersonalRelationshipsContactDtoList(
+    val prContacts = createPersonalRelationshipsPrisonerContactDtoList(
       contactIds = visitorIds,
       prisonerContactIds = prisonerContactIds,
       isApproved = true,
@@ -429,7 +429,7 @@ class PrisonerGetApprovedSocialContactsTest : IntegrationTestBase() {
     }
   }
 
-  private fun getContactResults(returnResult: WebTestClient.BodyContentSpec): Array<ContactDto> = TestObjectMapper.mapper.readValue(returnResult.returnResult().responseBody, Array<ContactDto>::class.java)
+  private fun getContactResults(returnResult: WebTestClient.BodyContentSpec): Array<PrisonerContactDto> = TestObjectMapper.mapper.readValue(returnResult.returnResult().responseBody, Array<PrisonerContactDto>::class.java)
 
   private fun callGetApprovedSocialContacts(
     prisonerId: String,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/v2/PrisonerGetContactViaRelationshipIdTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/v2/PrisonerGetContactViaRelationshipIdTest.kt
@@ -9,8 +9,8 @@ import org.mockito.kotlin.verify
 import org.springframework.http.HttpStatus
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.controller.V2_GET_PRISONER_CONTACT_RELATIONSHIP_CONTROLLER_PATH
-import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.ContactDto
-import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PersonalRelationshipsContactDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.PrisonerContactDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PersonalRelationshipsPrisonerContactDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PrisonerContactRestrictionsDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PrisonerContactRestrictionsResponseDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.integration.IntegrationTestBase
@@ -57,10 +57,10 @@ class PrisonerGetContactViaRelationshipIdTest : IntegrationTestBase() {
 
     val relationshipIds = listOf(999001L, 999002L)
 
-    val prContacts = mutableListOf<PersonalRelationshipsContactDto>()
+    val prContacts = mutableListOf<PersonalRelationshipsPrisonerContactDto>()
 
     prContacts.addAll(
-      createPersonalRelationshipsContactDtoList(
+      createPersonalRelationshipsPrisonerContactDtoList(
         contactIds = contactIds,
         prisonerContactIds = relationshipIds,
       ),
@@ -123,10 +123,10 @@ class PrisonerGetContactViaRelationshipIdTest : IntegrationTestBase() {
 
     val relationshipIds = listOf(999001L, 999002L)
 
-    val prContacts = mutableListOf<PersonalRelationshipsContactDto>()
+    val prContacts = mutableListOf<PersonalRelationshipsPrisonerContactDto>()
 
     prContacts.addAll(
-      createPersonalRelationshipsContactDtoList(
+      createPersonalRelationshipsPrisonerContactDtoList(
         contactIds = contactIds,
         prisonerContactIds = relationshipIds,
       ),
@@ -163,7 +163,7 @@ class PrisonerGetContactViaRelationshipIdTest : IntegrationTestBase() {
     val contactId = 2187525L
     val relationshipId = 999001L
 
-    val prContacts = createPersonalRelationshipsContactDtoList(
+    val prContacts = createPersonalRelationshipsPrisonerContactDtoList(
       contactIds = listOf(contactId),
       prisonerContactIds = listOf(relationshipId),
     )
@@ -184,7 +184,7 @@ class PrisonerGetContactViaRelationshipIdTest : IntegrationTestBase() {
     result.expectStatus().isBadRequest
   }
 
-  private fun getResults(returnResult: WebTestClient.BodyContentSpec): ContactDto = TestObjectMapper.mapper.readValue(returnResult.returnResult().responseBody, ContactDto::class.java)
+  private fun getResults(returnResult: WebTestClient.BodyContentSpec): PrisonerContactDto = TestObjectMapper.mapper.readValue(returnResult.returnResult().responseBody, PrisonerContactDto::class.java)
 
   private fun callGetPrisonerContactViaRelationshipId(
     prisonerId: String,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/v2/PrisonerGetSocialContactsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/v2/PrisonerGetSocialContactsTest.kt
@@ -9,8 +9,8 @@ import org.mockito.kotlin.verify
 import org.springframework.http.HttpStatus
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.controller.V2_PRISONER_GET_SOCIAL_CONTACTS_CONTROLLER_PATH
-import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.ContactDto
-import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PersonalRelationshipsContactDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.PrisonerContactDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PersonalRelationshipsPrisonerContactDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PrisonerContactRestrictionsDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PrisonerContactRestrictionsResponseDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.integration.IntegrationTestBase
@@ -52,7 +52,7 @@ class PrisonerGetSocialContactsTest : IntegrationTestBase() {
       val visitorIds: List<Long> = listOf(2187525L)
 
       val prisonerContactIds = listOf(999001L)
-      val prContacts = createPersonalRelationshipsContactDtoList(
+      val prContacts = createPersonalRelationshipsPrisonerContactDtoList(
         contactIds = visitorIds,
         prisonerContactIds = prisonerContactIds,
         isApproved = false,
@@ -81,10 +81,10 @@ class PrisonerGetSocialContactsTest : IntegrationTestBase() {
     val visitorIds: List<Long> = listOf(socialContactWithRestrictionId, socialContactWithExpiredRestrictionId)
     val prisonerContactIds = listOf(999001L, 999002L)
 
-    val prContacts = mutableListOf<PersonalRelationshipsContactDto>()
+    val prContacts = mutableListOf<PersonalRelationshipsPrisonerContactDto>()
 
     prContacts.addAll(
-      createPersonalRelationshipsContactDtoList(
+      createPersonalRelationshipsPrisonerContactDtoList(
         contactIds = visitorIds,
         prisonerContactIds = prisonerContactIds,
         isApproved = false,
@@ -92,7 +92,7 @@ class PrisonerGetSocialContactsTest : IntegrationTestBase() {
     )
 
     prContacts.add(
-      PersonalRelationshipsContactDto(
+      PersonalRelationshipsPrisonerContactDto(
         contactId = socialContactWithNoDOB,
         prisonerContactId = 999003L,
         firstName = "test",
@@ -184,10 +184,10 @@ class PrisonerGetSocialContactsTest : IntegrationTestBase() {
     val visitorIds: List<Long> = listOf(socialContactWithRestrictionId, socialContactWithExpiredRestrictionId)
     val prisonerContactIds = listOf(999001L, 999002L)
 
-    val prContacts = mutableListOf<PersonalRelationshipsContactDto>()
+    val prContacts = mutableListOf<PersonalRelationshipsPrisonerContactDto>()
 
     prContacts.addAll(
-      createPersonalRelationshipsContactDtoList(
+      createPersonalRelationshipsPrisonerContactDtoList(
         contactIds = visitorIds,
         prisonerContactIds = prisonerContactIds,
         isApproved = false,
@@ -195,7 +195,7 @@ class PrisonerGetSocialContactsTest : IntegrationTestBase() {
     )
 
     prContacts.add(
-      PersonalRelationshipsContactDto(
+      PersonalRelationshipsPrisonerContactDto(
         contactId = socialContactWithNoDOB,
         prisonerContactId = 999003L,
         firstName = "test",
@@ -287,10 +287,10 @@ class PrisonerGetSocialContactsTest : IntegrationTestBase() {
     val visitorIds: List<Long> = listOf(socialContactWithRestrictionId, socialContactWithExpiredRestrictionId)
     val prisonerContactIds = listOf(999001L, 999002L)
 
-    val prContacts = mutableListOf<PersonalRelationshipsContactDto>()
+    val prContacts = mutableListOf<PersonalRelationshipsPrisonerContactDto>()
 
     prContacts.addAll(
-      createPersonalRelationshipsContactDtoList(
+      createPersonalRelationshipsPrisonerContactDtoList(
         contactIds = visitorIds,
         prisonerContactIds = prisonerContactIds,
         isApproved = false,
@@ -298,7 +298,7 @@ class PrisonerGetSocialContactsTest : IntegrationTestBase() {
     )
 
     prContacts.add(
-      PersonalRelationshipsContactDto(
+      PersonalRelationshipsPrisonerContactDto(
         contactId = socialContactWithNoDOB,
         prisonerContactId = 999003L,
         firstName = "test",
@@ -356,7 +356,7 @@ class PrisonerGetSocialContactsTest : IntegrationTestBase() {
     val visitorIds: List<Long> = listOf(2187525L)
 
     val prisonerContactIds = listOf(999001L)
-    val prContacts = createPersonalRelationshipsContactDtoList(
+    val prContacts = createPersonalRelationshipsPrisonerContactDtoList(
       contactIds = visitorIds,
       prisonerContactIds = prisonerContactIds,
       isApproved = false,
@@ -378,7 +378,7 @@ class PrisonerGetSocialContactsTest : IntegrationTestBase() {
     result.expectStatus().isBadRequest
   }
 
-  private fun getContactResults(returnResult: WebTestClient.BodyContentSpec): Array<ContactDto> = TestObjectMapper.mapper.readValue(returnResult.returnResult().responseBody, Array<ContactDto>::class.java)
+  private fun getContactResults(returnResult: WebTestClient.BodyContentSpec): Array<PrisonerContactDto> = TestObjectMapper.mapper.readValue(returnResult.returnResult().responseBody, Array<PrisonerContactDto>::class.java)
 
   private fun callGetSocialContacts(
     prisonerId: String,


### PR DESCRIPTION
## What does this pull request do?

This new endpoint allows you to get a Contact without a prisoner contact relationship being present.

Rename the old ContactDto -> PrisonerContactDto as it's specifically used for contacts with a prisoner relationship.

New ContactDto -> Only for contact without prisoner relationship.

Add new tests to cover new endpoint.

## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-6616