### PR TITLE
[BUG] VB-5817 - Search for prisoner contacts directly given a prisonerId and contactIds

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/client/PersonalRelationshipsApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/client/PersonalRelationshipsApiClient.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.ContactDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.ContactLinkedPrisonerDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.GlobalContactRestrictionDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PersonalRelationshipsContactDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PersonalRelationshipsContactSearchResultDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PersonalRelationshipsPrisonerContactDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PrisonerContactIdsRequestDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PrisonerContactRestrictionsResponseDto
@@ -161,6 +162,32 @@ class PersonalRelationshipsApiClient(
       }
       .blockOptional(apiTimeout)
       .orElseThrow { IllegalStateException("Timeout getting contact for - $prisonerId on personal-relationships-api") }
+      .content
+  }
+
+  fun searchContact(prisonerId: String, contactIds: List<Long>): List<PersonalRelationshipsContactSearchResultDto> {
+    logger.info("searchContact called for $prisonerId, with contactIds ${contactIds.forEach { it.toString() }} via the personal-relationships-api")
+
+    val uri = "/contact/search"
+
+    return webClient.get()
+      .uri { uriBuilder ->
+        uriBuilder
+          .path(uri)
+          .queryParam("includePrisonerRelationships", prisonerId)
+          .queryParam("contactIds", contactIds.joinToString(","))
+          .queryParam("searchType", "EXACT")
+          .queryParam("size", 400)
+          .build()
+      }
+      .retrieve()
+      .bodyToMono(object : ParameterizedTypeReference<PagedResponse<PersonalRelationshipsContactSearchResultDto>>() {})
+      .onErrorResume { e ->
+        logger.error("searchContact Failed for get request $uri")
+        Mono.error(e)
+      }
+      .blockOptional(apiTimeout)
+      .orElseThrow { IllegalStateException("Timeout calling searchContact - $prisonerId / ${contactIds.forEach { it.toString() }} on personal-relationships-api") }
       .content
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/client/PersonalRelationshipsApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/client/PersonalRelationshipsApiClient.kt
@@ -166,7 +166,7 @@ class PersonalRelationshipsApiClient(
   }
 
   fun searchContact(prisonerId: String, contactIds: List<Long>): List<PersonalRelationshipsContactSearchResultDto> {
-    logger.info("searchContact called for $prisonerId, with contactIds ${contactIds.forEach { it.toString() }} via the personal-relationships-api")
+    logger.info("searchContact called for $prisonerId, with contactIds ${contactIds.joinToString { it.toString() }} via the personal-relationships-api")
 
     val uri = "/contact/search"
 
@@ -177,7 +177,6 @@ class PersonalRelationshipsApiClient(
           .queryParam("includePrisonerRelationships", prisonerId)
           .queryParam("contactIds", contactIds.joinToString(","))
           .queryParam("searchType", "EXACT")
-          .queryParam("size", 400)
           .build()
       }
       .retrieve()
@@ -187,7 +186,7 @@ class PersonalRelationshipsApiClient(
         Mono.error(e)
       }
       .blockOptional(apiTimeout)
-      .orElseThrow { IllegalStateException("Timeout calling searchContact - $prisonerId / ${contactIds.forEach { it.toString() }} on personal-relationships-api") }
+      .orElseThrow { IllegalStateException("Timeout calling searchContact - $prisonerId / ${contactIds.joinToString { it.toString() }} on personal-relationships-api") }
       .content
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/client/PersonalRelationshipsApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/client/PersonalRelationshipsApiClient.kt
@@ -177,6 +177,8 @@ class PersonalRelationshipsApiClient(
           .queryParam("includePrisonerRelationships", prisonerId)
           .queryParam("contactIds", contactIds.joinToString(","))
           .queryParam("searchType", "EXACT")
+          .queryParam("page", 0)
+          .queryParam("size", 50)
           .build()
       }
       .retrieve()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/PrisonerContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/PrisonerContactController.kt
@@ -103,7 +103,7 @@ class PrisonerContactController(private val contactService: PrisonerContactFacad
   @GetMapping(V2_PRISONER_SEARCH_CONTACTS)
   @Operation(
     summary = "Search for contacts with a potential relationship to a prisoner",
-    description = "Returns details contact (including relationship details of prisoner if found)",
+    description = "Returns contact details (including relationship details of prisoner if found)",
     responses = [
       ApiResponse(
         responseCode = "200",
@@ -130,7 +130,7 @@ class PrisonerContactController(private val contactService: PrisonerContactFacad
     @Schema(description = "Prisoner Identifier (NOMIS Offender No)", example = "A1234AA", required = true)
     @PathVariable
     prisonerId: String,
-    @RequestParam(required = false)
+    @RequestParam(required = true)
     @Parameter(`in` = ParameterIn.QUERY, description = "Contact IDs. Comma-separated list of contact IDs, e.g. contactIds=123,456,789", example = "123,456,789", required = true)
     contactIds: List<Long>,
     @RequestParam(required = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/PrisonerContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/PrisonerContactController.kt
@@ -103,7 +103,7 @@ class PrisonerContactController(private val contactService: PrisonerContactFacad
   @GetMapping(V2_PRISONER_SEARCH_CONTACTS)
   @Operation(
     summary = "Search for contacts with a potential relationship to a prisoner",
-    description = "Returns contact details (including relationship details of prisoner if found)",
+    description = "Returns contact details (including relationship details of prisoner if found). It does NOT filter to only return social contacts",
     responses = [
       ApiResponse(
         responseCode = "200",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/PrisonerContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/PrisonerContactController.kt
@@ -103,7 +103,7 @@ class PrisonerContactController(private val contactService: PrisonerContactFacad
   @GetMapping(V2_PRISONER_SEARCH_CONTACTS)
   @Operation(
     summary = "Search for contacts with a potential relationship to a prisoner",
-    description = "Returns contact details (including relationship details of prisoner if found)",
+    description = "Returns contact details (including relationship details of prisoner if found). Filters out Official contacts in response.",
     responses = [
       ApiResponse(
         responseCode = "200",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/PrisonerContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/PrisonerContactController.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.prisonercontactregistry.controller
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.ContactWithOptionalPrisonerRelationshipDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.DateRangeDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.HasClosedRestrictionDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.PrisonerContactDto
@@ -27,6 +29,7 @@ import uk.gov.justice.digital.hmpps.prisonercontactregistry.service.PrisonerCont
 import java.time.LocalDate
 
 const val V2_PRISONER_CONTACTS_CONTROLLER_PATH: String = "v2/prisoners/{prisonerId}"
+const val V2_PRISONER_SEARCH_CONTACTS = "$V2_PRISONER_CONTACTS_CONTROLLER_PATH/contacts/search"
 const val V2_PRISONER_GET_SOCIAL_CONTACTS_CONTROLLER_PATH: String = "$V2_PRISONER_CONTACTS_CONTROLLER_PATH/contacts/social"
 const val V2_PRISONER_GET_SOCIAL_CONTACTS_APPROVED_CONTROLLER_PATH: String = "$V2_PRISONER_GET_SOCIAL_CONTACTS_CONTROLLER_PATH/approved"
 const val V2_PRISONER_GET_SOCIAL_RESTRICTION_CLOSED_CONTROLLER_PATH: String = "$V2_PRISONER_GET_SOCIAL_CONTACTS_APPROVED_CONTROLLER_PATH/restrictions/closed"
@@ -92,6 +95,53 @@ class PrisonerContactController(private val contactService: PrisonerContactFacad
       prisonerId = prisonerId,
       hasDateOfBirth = hasDateOfBirth ?: false,
       approvedContactsOnly = false,
+      withRestrictions = withRestrictions ?: false,
+    )
+  }
+
+  @PreAuthorize("hasRole('PRISONER_CONTACT_REGISTRY')")
+  @GetMapping(V2_PRISONER_SEARCH_CONTACTS)
+  @Operation(
+    summary = "Search for contacts with a potential relationship to a prisoner",
+    description = "Returns details contact (including relationship details of prisoner if found)",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Contact information returned, including relationship details of prisoner if found",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Incorrect request to search for contacts with a potential relationship to a prisoner",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Incorrect permissions to search for contacts with a potential relationship to a prisoner",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun searchContacts(
+    @Schema(description = "Prisoner Identifier (NOMIS Offender No)", example = "A1234AA", required = true)
+    @PathVariable
+    prisonerId: String,
+    @RequestParam(required = false)
+    @Parameter(`in` = ParameterIn.QUERY, description = "Contact IDs. Comma-separated list of contact IDs, e.g. contactIds=123,456,789", example = "123,456,789", required = true)
+    contactIds: List<Long>,
+    @RequestParam(required = false)
+    @Parameter(description = "Defaults to false. Returns all contacts restrictions if set to true, skips grabbing restrictions if false", example = "false")
+    withRestrictions: Boolean? = false,
+  ): List<ContactWithOptionalPrisonerRelationshipDto> {
+    log.debug("searchContacts called with params : Prisoner: {}, contactIds = {}, withRestrictions = {}", prisonerId, contactIds, withRestrictions)
+
+    return contactService.searchContacts(
+      prisonerId = prisonerId,
+      contactIds = contactIds,
       withRestrictions = withRestrictions ?: false,
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/PrisonerContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/PrisonerContactController.kt
@@ -103,7 +103,7 @@ class PrisonerContactController(private val contactService: PrisonerContactFacad
   @GetMapping(V2_PRISONER_SEARCH_CONTACTS)
   @Operation(
     summary = "Search for contacts with a potential relationship to a prisoner",
-    description = "Returns contact details (including relationship details of prisoner if found). It does NOT filter to only return social contacts",
+    description = "Returns contact details (including relationship details of prisoner if found)",
     responses = [
       ApiResponse(
         responseCode = "200",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/ContactWithOptionalPrisonerRelationshipDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/ContactWithOptionalPrisonerRelationshipDto.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.prisonercontactregistry.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+@Schema(description = "A contact with an optional prisoner relationship")
+data class ContactWithOptionalPrisonerRelationshipDto(
+  @param:Schema(description = "Identifier for this contact (Person in NOMIS)", example = "5871791", required = true)
+  val contactId: Long,
+  @param:Schema(description = "The unique identifier for the prisoner-contact relationship", example = "123456", required = false)
+  val prisonerContactId: Long? = null,
+  @param:Schema(description = "First name", example = "John", required = true)
+  val firstName: String,
+  @param:Schema(description = "Middle name", example = "Mark", required = false)
+  val middleName: String? = null,
+  @param:Schema(description = "Last name", example = "Smith", required = true)
+  val lastName: String,
+  @param:Schema(description = "Date of birth", example = "1980-01-28", required = false)
+  val dateOfBirth: LocalDate? = null,
+  @param:Schema(description = "Code for relationship to Prisoner", example = "RO", required = false)
+  val relationshipCode: String?,
+  @param:Schema(description = "Description of relationship to Prisoner", example = "Responsible Officer", required = false)
+  val relationshipDescription: String? = null,
+  @param:Schema(description = "Type of Contact", example = "O", required = false)
+  val contactType: String?,
+  @param:Schema(description = "Description of Contact Type", example = "Official", required = false)
+  val contactTypeDescription: String? = null,
+  @param:Schema(description = "List of restrictions associated with the contact", required = false)
+  val restrictions: List<RestrictionDto> = listOf(),
+  @param:Schema(description = "Address associated with the contact", required = false)
+  val address: AddressDto? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/personal/relationships/ExistingRelationshipToPrisoner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/personal/relationships/ExistingRelationshipToPrisoner.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class ExistingRelationshipToPrisoner(
+  @param:Schema(description = "The unique identifier for the prisoner contact", example = "123456")
+  val prisonerContactId: Long,
+
+  @param:Schema(
+    description =
+    """
+      Coded value indicating either a social or official contact (mandatory).
+      This is a coded value from the group code CONTACT_TYPE in reference data.
+      Known values are (S) Social or (O) official.
+      """,
+    example = "S",
+  )
+  val relationshipTypeCode: String,
+
+  @param:Schema(description = "The description of the contact relationship type. Description from reference data Official or Social", example = "Official")
+  val relationshipTypeDescription: String,
+
+  @param:Schema(description = "The relationship to the prisoner. A code from SOCIAL_RELATIONSHIP or OFFICIAL_RELATIONSHIP reference data groups depending on the relationship type.", example = "FRI")
+  val relationshipToPrisonerCode: String,
+
+  @param:Schema(description = "The description of the relationship", example = "Friend", nullable = true)
+  val relationshipToPrisonerDescription: String?,
+
+  @param:Schema(description = "Is this prisoner's contact relationship active?", example = "true")
+  val isRelationshipActive: Boolean,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/personal/relationships/ExistingRelationshipToPrisonerDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/personal/relationships/ExistingRelationshipToPrisonerDto.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relati
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-data class ExistingRelationshipToPrisoner(
+data class ExistingRelationshipToPrisonerDto(
   @param:Schema(description = "The unique identifier for the prisoner contact", example = "123456")
   val prisonerContactId: Long,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/personal/relationships/PersonalRelationshipsContactSearchResultDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/personal/relationships/PersonalRelationshipsContactSearchResultDto.kt
@@ -107,7 +107,7 @@ data class PersonalRelationshipsContactSearchResultDto(
     nullable = true,
     required = false,
   )
-  val existingRelationships: List<ExistingRelationshipToPrisoner>? = null,
+  val existingRelationships: List<ExistingRelationshipToPrisonerDto>? = null,
 )
 
 fun PersonalRelationshipsContactSearchResultDto.toContactWithOptionalPrisonerRelationshipDto(): List<ContactWithOptionalPrisonerRelationshipDto> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/personal/relationships/PersonalRelationshipsContactSearchResultDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/personal/relationships/PersonalRelationshipsContactSearchResultDto.kt
@@ -1,0 +1,181 @@
+package uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships
+
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.AddressDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.ContactWithOptionalPrisonerRelationshipDto
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Schema(description = "The details of a contact as an individual with a list of any prisoner relationships they have")
+data class PersonalRelationshipsContactSearchResultDto(
+
+  @param:Schema(description = "The id of the contact", example = "123456")
+  val id: Long,
+
+  @param:Schema(description = "The last name of the contact", example = "Doe")
+  val lastName: String,
+
+  @param:Schema(description = "The first name of the contact", example = "John")
+  val firstName: String,
+
+  @param:Schema(description = "The middle name of the contact, if any", example = "William", nullable = true)
+  val middleNames: String? = null,
+
+  @param:Schema(description = "The date of birth of the contact, if known", example = "1980-01-01", nullable = true)
+  val dateOfBirth: LocalDate? = null,
+
+  @param:Schema(description = "The date the contact deceased, if known", example = "1980-01-01", nullable = true)
+  val deceasedDate: LocalDate? = null,
+
+  @param:Schema(description = "The id of the user who created the contact", example = "JD000001")
+  val createdBy: String? = null,
+
+  @param:Schema(description = "The timestamp of when the contact was created", example = "2024-01-01T00:00:00Z")
+  val createdTime: LocalDateTime? = null,
+
+  @param:Schema(description = "The flat of the contact address, if known", example = "01", nullable = true)
+  val flat: String? = null,
+
+  @param:Schema(description = "The property of the contact address, if known", example = "01", nullable = true)
+  val property: String? = null,
+
+  @param:Schema(description = "The street of the contact address, if known", example = "Bluebell Crescent", nullable = true)
+  val street: String? = null,
+
+  @param:Schema(description = "The area of the contact address, if known", example = "Birmingham", nullable = true)
+  val area: String? = null,
+
+  @param:Schema(description = "The city code of the contact address, if known", example = "25343", nullable = true)
+  val cityCode: String? = null,
+
+  @param:Schema(description = "The description of city code, if known", example = "Sheffield", nullable = true)
+  val cityDescription: String? = null,
+
+  @param:Schema(description = "The county code of the contact address, if known", example = "S.YORKSHIRE", nullable = true)
+  val countyCode: String? = null,
+
+  @param:Schema(description = "The description of county code, if known", example = "South Yorkshire", nullable = true)
+  val countyDescription: String? = null,
+
+  @param:Schema(description = "The postcode of the contact address, if known", example = "B42 2QJ", nullable = true)
+  val postcode: String? = null,
+
+  @param:Schema(description = "The country code of the contact address, if known", example = "ENG", nullable = true)
+  val countryCode: String? = null,
+
+  @param:Schema(description = "The description of country code, if known", example = "England", nullable = true)
+  val countryDescription: String? = null,
+
+  @param:Schema(
+    description = "If true this address should be considered for sending mail to",
+    nullable = true,
+    example = "true",
+  )
+  val mailAddress: Boolean?,
+
+  @param:Schema(
+    description = "The date from which this address can be considered active",
+    example = "2022-10-01",
+    nullable = true,
+  )
+  val startDate: LocalDate? = null,
+
+  @param:Schema(
+    description = "The date after which this address should be considered inactive",
+    example = "2023-10-02",
+    nullable = true,
+  )
+  val endDate: LocalDate? = null,
+
+  @param:Schema(
+    description = "A flag to indicate that this address is effectively no fixed address",
+    example = "false",
+    nullable = true,
+  )
+  val noFixedAddress: Boolean? = false,
+
+  @param:Schema(
+    description = "Any additional information or comments about the address",
+    example = "Some additional information",
+    nullable = true,
+  )
+  val comments: String?,
+
+  @param:Schema(
+    description = "A list of existing relationships to a prisoner if a check against the prisoner number was requested. " +
+      "Empty if there are no existing relationships or null if it was not requested.",
+    nullable = true,
+    required = false,
+  )
+  val existingRelationships: List<ExistingRelationshipToPrisoner>? = null,
+)
+
+fun PersonalRelationshipsContactSearchResultDto.toContactWithOptionalPrisonerRelationshipDto(): List<ContactWithOptionalPrisonerRelationshipDto> {
+  val address = if (
+    listOf(
+      flat,
+      property,
+      street,
+      area,
+      cityDescription,
+      postcode,
+      countyDescription,
+      countryDescription,
+      comments,
+    ).any { it != null } ||
+    mailAddress == true ||
+    noFixedAddress == true
+  ) {
+    AddressDto(
+      flat = flat,
+      premise = property,
+      street = street,
+      locality = area,
+      town = cityDescription,
+      postalCode = postcode,
+      county = countyDescription,
+      country = countryDescription,
+      comment = comments,
+      primary = mailAddress ?: false,
+      noFixedAddress = noFixedAddress ?: false,
+    )
+  } else {
+    null
+  }
+
+  return if (existingRelationships.isNullOrEmpty()) {
+    listOf(
+      ContactWithOptionalPrisonerRelationshipDto(
+        contactId = id,
+        prisonerContactId = null,
+        firstName = firstName,
+        middleName = middleNames,
+        lastName = lastName,
+        dateOfBirth = dateOfBirth,
+        relationshipCode = null,
+        relationshipDescription = null,
+        contactType = null,
+        contactTypeDescription = null,
+        restrictions = emptyList(),
+        address = address,
+      ),
+    )
+  } else {
+    existingRelationships.map { relationship ->
+      ContactWithOptionalPrisonerRelationshipDto(
+        contactId = id,
+        prisonerContactId = relationship.prisonerContactId,
+        firstName = firstName,
+        middleName = middleNames,
+        lastName = lastName,
+        dateOfBirth = dateOfBirth,
+        relationshipCode = relationship.relationshipToPrisonerCode,
+        relationshipDescription = relationship.relationshipToPrisonerDescription,
+        contactType = relationship.relationshipTypeCode,
+        contactTypeDescription = relationship.relationshipTypeDescription,
+        restrictions = emptyList(),
+        address = address,
+      )
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/service/PrisonerContactFacadeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/service/PrisonerContactFacadeService.kt
@@ -34,7 +34,7 @@ class PrisonerContactFacadeService(
     val foundContacts = prisonerContactService.searchContacts(prisonerId, contactIds)
 
     val contacts = foundContacts.flatMap { contact ->
-      contact.toContactWithOptionalPrisonerRelationshipDto()
+      contact.toContactWithOptionalPrisonerRelationshipDto().filter { it.contactType != "O" }
     }
 
     if (!withRestrictions) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/service/PrisonerContactFacadeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/service/PrisonerContactFacadeService.kt
@@ -4,9 +4,11 @@ import org.apache.coyote.BadRequestException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.ContactWithOptionalPrisonerRelationshipDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.DateRangeDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.HasClosedRestrictionDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.PrisonerContactDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.toContactWithOptionalPrisonerRelationshipDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.visit.scheduler.RequestVisitVisitorRestrictionsBodyDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.exception.VisitorNotFoundException
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.mappers.IndexedRestrictions
@@ -19,6 +21,55 @@ class PrisonerContactFacadeService(
 ) {
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  // TODO: Confirm should we be filtering on this endpoint to only keep "S" Social contacts? Or because it's hand fed the IDs, do we just return the info?
+  fun searchContacts(prisonerId: String, contactIds: List<Long>, withRestrictions: Boolean): List<ContactWithOptionalPrisonerRelationshipDto> {
+    log.debug(
+      "searchContacts called with parameters : prisonerId - {}, contactIds - {}, withRestrictions - {}",
+      prisonerId,
+      contactIds,
+      withRestrictions,
+    )
+
+    val foundContacts = prisonerContactService.searchContacts(prisonerId, contactIds)
+
+    val contacts = foundContacts.flatMap { contact ->
+      contact.toContactWithOptionalPrisonerRelationshipDto()
+    }
+
+    if (!withRestrictions) {
+      return contacts
+    }
+
+    val indexedGlobalAndLocalRestrictions = restrictionsService.getContactsGlobalAndLocalRestrictions(
+      contacts
+        .mapNotNull { it.prisonerContactId }
+        .distinct(),
+    )
+
+    // Because local restrictions are bound between prisoner and contact, if relationship is null we need to do a separate
+    // global restrictions lookup for these contacts.
+    val globalRestrictionsByContactId = contacts
+      .filter { it.prisonerContactId == null }
+      .map { it.contactId }
+      .distinct()
+      .associateWith { contactId ->
+        restrictionsService.getContactGlobalRestrictions(contactId)
+      }
+
+    return contacts.map { contact ->
+      val restrictions = if (contact.prisonerContactId != null) {
+        indexedGlobalAndLocalRestrictions.forContact(
+          contactId = contact.contactId,
+          prisonerContactId = contact.prisonerContactId,
+        )
+      } else {
+        globalRestrictionsByContactId[contact.contactId].orEmpty()
+      }
+
+      contact.copy(restrictions = restrictions)
+    }
   }
 
   fun getSocialContactList(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/service/PrisonerContactFacadeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/service/PrisonerContactFacadeService.kt
@@ -23,7 +23,6 @@ class PrisonerContactFacadeService(
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  // TODO: Confirm should we be filtering on this endpoint to only keep "S" Social contacts? Or because it's hand fed the IDs, do we just return the info?
   fun searchContacts(prisonerId: String, contactIds: List<Long>, withRestrictions: Boolean): List<ContactWithOptionalPrisonerRelationshipDto> {
     log.debug(
       "searchContacts called with parameters : prisonerId - {}, contactIds - {}, withRestrictions - {}",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/service/PrisonerContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/service/PrisonerContactService.kt
@@ -23,4 +23,9 @@ class PrisonerContactService(private val personalRelationshipsApiClient: Persona
     contactId = contactId,
     relationshipId = relationshipId,
   )
+
+  fun searchContacts(
+    prisonerId: String,
+    contactIds: List<Long>,
+  ) = personalRelationshipsApiClient.searchContact(prisonerId, contactIds)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/service/RestrictionsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/service/RestrictionsService.kt
@@ -27,9 +27,7 @@ class RestrictionsService(private val personalRelationshipsApiClient: PersonalRe
     return personalRelationshipsApiClient.getContactGlobalRestrictions(contactId).map { it.toRestrictionDto() }
   }
 
-  fun getContactsGlobalAndLocalRestrictions(
-    prisonerContactRelationshipIds: List<Long>,
-  ): IndexedRestrictions {
+  fun getContactsGlobalAndLocalRestrictions(prisonerContactRelationshipIds: List<Long>): IndexedRestrictions {
     if (prisonerContactRelationshipIds.isEmpty()) {
       return IndexedRestrictions.EMPTY
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/IntegrationTestBase.kt
@@ -15,7 +15,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.client.PersonalRelationshipsApiClient
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.AddressDto
-import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.ExistingRelationshipToPrisoner
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.ExistingRelationshipToPrisonerDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.GlobalContactRestrictionDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PersonalRelationshipsContactDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PersonalRelationshipsContactSearchResultDto
@@ -142,7 +142,7 @@ abstract class IntegrationTestBase {
 
   fun createPersonalRelationshipsContactSearchResultRelationshipDto(
     prisonerContactId: Long,
-  ): ExistingRelationshipToPrisoner = ExistingRelationshipToPrisoner(
+  ): ExistingRelationshipToPrisonerDto = ExistingRelationshipToPrisonerDto(
     prisonerContactId = prisonerContactId,
     relationshipToPrisonerCode = "FRI",
     relationshipToPrisonerDescription = "Friend",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/IntegrationTestBase.kt
@@ -15,8 +15,10 @@ import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.client.PersonalRelationshipsApiClient
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.AddressDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.ExistingRelationshipToPrisoner
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.GlobalContactRestrictionDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PersonalRelationshipsContactDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PersonalRelationshipsContactSearchResultDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PersonalRelationshipsPrisonerContactDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PrisonerContactRestrictionDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.helper.JwtAuthHelper
@@ -91,6 +93,62 @@ abstract class IntegrationTestBase {
     middleNames = middleNames,
     lastName = lastName,
     dateOfBirth = dateOfBirth,
+  )
+
+  fun createPersonalRelationshipsContactSearchResultDtoList(
+    contactIds: List<Long>,
+    prisonerContactIds: List<Long?> = List(contactIds.size) { null },
+  ): List<PersonalRelationshipsContactSearchResultDto> {
+    require(contactIds.size == prisonerContactIds.size) {
+      "contactIds and prisonerContactIds must be the same size"
+    }
+
+    return contactIds.mapIndexed { index, contactId ->
+      createPersonalRelationshipsContactSearchResultDto(
+        contactId = contactId,
+        prisonerContactId = prisonerContactIds[index],
+      )
+    }
+  }
+
+  fun createPersonalRelationshipsContactSearchResultDto(
+    contactId: Long,
+    prisonerContactId: Long? = null,
+  ): PersonalRelationshipsContactSearchResultDto = PersonalRelationshipsContactSearchResultDto(
+    id = contactId,
+    firstName = "test",
+    middleNames = "middle",
+    lastName = "user",
+    dateOfBirth = LocalDate.of(1912, 9, 13),
+    flat = "Flat 1",
+    property = "221B",
+    street = "Baker Street",
+    area = "Marylebone",
+    cityDescription = "London",
+    countyDescription = "Greater London",
+    postcode = "NW1 6XE",
+    countryDescription = "England",
+    noFixedAddress = false,
+    existingRelationships = prisonerContactId?.let {
+      listOf(
+        createPersonalRelationshipsContactSearchResultRelationshipDto(
+          prisonerContactId = it,
+        ),
+      )
+    },
+    mailAddress = true,
+    comments = "blah blah blah",
+  )
+
+  fun createPersonalRelationshipsContactSearchResultRelationshipDto(
+    prisonerContactId: Long,
+  ): ExistingRelationshipToPrisoner = ExistingRelationshipToPrisoner(
+    prisonerContactId = prisonerContactId,
+    relationshipToPrisonerCode = "FRI",
+    relationshipToPrisonerDescription = "Friend",
+    relationshipTypeCode = "S",
+    relationshipTypeDescription = "Social",
+    isRelationshipActive = true,
   )
 
   fun createPersonalRelationshipsPrisonerContactDtoList(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/mock/PersonalRelationshipsApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/mock/PersonalRelationshipsApiMockServer.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.prisonercontactregistry.client.PagedResponse
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.ContactLinkedPrisonerDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.GlobalContactRestrictionDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PersonalRelationshipsContactDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PersonalRelationshipsContactSearchResultDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PersonalRelationshipsPrisonerContactDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PrisonerContactIdsRequestDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PrisonerContactRestrictionsDto
@@ -41,6 +42,49 @@ class PersonalRelationshipsApiMockServer : WireMockServer(8093) {
     }
 
     stubFor(get(urlPathEqualTo(uri)).willReturn(response))
+  }
+
+  fun stubSearchContacts(
+    prisonerId: String,
+    contactIds: List<Long>,
+    contacts: List<PersonalRelationshipsContactSearchResultDto>? = null,
+    page: Int = 0,
+    size: Int = 400,
+    httpStatus: HttpStatus = HttpStatus.OK,
+  ) {
+    val uri = "/contact/search"
+
+    val response = if (contacts == null) {
+      aResponse().withStatus(httpStatus.value())
+    } else {
+      val totalElements = contacts.size.toLong()
+      val totalPages = if (size <= 0) 0 else kotlin.math.ceil(totalElements.toDouble() / size.toDouble()).toInt()
+
+      aResponse()
+        .withStatus(httpStatus.value())
+        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        .withBody(
+          TestObjectMapper.mapper.writeValueAsString(
+            PagedResponse(
+              content = contacts,
+              page = PageMetadata(
+                size = size,
+                number = page,
+                totalElements = totalElements,
+                totalPages = totalPages,
+              ),
+            ),
+          ),
+        )
+    }
+
+    stubFor(
+      get(urlPathEqualTo(uri))
+        .withQueryParam("includePrisonerRelationships", equalTo(prisonerId))
+        .withQueryParam("contactIds", equalTo(contactIds.joinToString(",")))
+        .withQueryParam("searchType", equalTo("EXACT"))
+        .willReturn(response),
+    )
   }
 
   fun stubGetAllContacts(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/mock/PersonalRelationshipsApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/mock/PersonalRelationshipsApiMockServer.kt
@@ -49,7 +49,7 @@ class PersonalRelationshipsApiMockServer : WireMockServer(8093) {
     contactIds: List<Long>,
     contacts: List<PersonalRelationshipsContactSearchResultDto>? = null,
     page: Int = 0,
-    size: Int = 400,
+    size: Int = 50,
     httpStatus: HttpStatus = HttpStatus.OK,
   ) {
     val uri = "/contact/search"
@@ -83,6 +83,8 @@ class PersonalRelationshipsApiMockServer : WireMockServer(8093) {
         .withQueryParam("includePrisonerRelationships", equalTo(prisonerId))
         .withQueryParam("contactIds", equalTo(contactIds.joinToString(",")))
         .withQueryParam("searchType", equalTo("EXACT"))
+        .withQueryParam("page", equalTo(page.toString()))
+        .withQueryParam("size", equalTo(size.toString()))
         .willReturn(response),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/v2/GetDateRangeVisitorBannedRestrictionTypeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/v2/GetDateRangeVisitorBannedRestrictionTypeTest.kt
@@ -11,7 +11,7 @@ import uk.gov.justice.digital.hmpps.prisonercontactregistry.integration.Integrat
 import java.time.LocalDate
 
 @Suppress("ClassName")
-@DisplayName("PrisonerContactControllerV2 - $V2_PRISONER_GET_SOCIAL_RESTRICTION_BANNED_DATE_RANGE_CONTROLLER_PATH")
+@DisplayName("PrisonerContactController - $V2_PRISONER_GET_SOCIAL_RESTRICTION_BANNED_DATE_RANGE_CONTROLLER_PATH")
 class GetDateRangeVisitorBannedRestrictionTypeTest : IntegrationTestBase() {
   @Nested
   inner class authentication {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/v2/GetVisitorClosedRestrictionTypeStatusTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/v2/GetVisitorClosedRestrictionTypeStatusTest.kt
@@ -10,7 +10,7 @@ import uk.gov.justice.digital.hmpps.prisonercontactregistry.integration.Integrat
 import java.time.LocalDate
 
 @Suppress("ClassName")
-@DisplayName("PrisonerContactControllerV2 - $V2_PRISONER_GET_SOCIAL_RESTRICTION_CLOSED_CONTROLLER_PATH")
+@DisplayName("PrisonerContactController - $V2_PRISONER_GET_SOCIAL_RESTRICTION_CLOSED_CONTROLLER_PATH")
 class GetVisitorClosedRestrictionTypeStatusTest : IntegrationTestBase() {
 
   @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/v2/PrisonerGetApprovedSocialContactsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/v2/PrisonerGetApprovedSocialContactsTest.kt
@@ -21,7 +21,7 @@ import uk.gov.justice.digital.hmpps.prisonercontactregistry.integration.TestObje
 import java.time.LocalDate
 
 @Suppress("ClassName")
-@DisplayName("PrisonerContactControllerV2 - $V2_PRISONER_GET_SOCIAL_CONTACTS_APPROVED_CONTROLLER_PATH")
+@DisplayName("PrisonerContactController - $V2_PRISONER_GET_SOCIAL_CONTACTS_APPROVED_CONTROLLER_PATH")
 class PrisonerGetApprovedSocialContactsTest : IntegrationTestBase() {
   val socialContactWithRestrictionId = 1L
   val socialContactWithExpiredRestrictionId = 2L

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/v2/PrisonerGetContactViaRelationshipIdTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/v2/PrisonerGetContactViaRelationshipIdTest.kt
@@ -18,7 +18,7 @@ import uk.gov.justice.digital.hmpps.prisonercontactregistry.integration.Integrat
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.integration.TestObjectMapper
 
 @Suppress("ClassName")
-@DisplayName("PrisonerContactControllerV2 - $V2_GET_PRISONER_CONTACT_RELATIONSHIP_CONTROLLER_PATH")
+@DisplayName("PrisonerContactController - $V2_GET_PRISONER_CONTACT_RELATIONSHIP_CONTROLLER_PATH")
 class PrisonerGetContactViaRelationshipIdTest : IntegrationTestBase() {
   @Nested
   inner class authentication {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/v2/PrisonerGetSocialContactsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/v2/PrisonerGetSocialContactsTest.kt
@@ -19,7 +19,7 @@ import uk.gov.justice.digital.hmpps.prisonercontactregistry.integration.TestObje
 import java.time.LocalDate
 
 @Suppress("ClassName")
-@DisplayName("PrisonerContactControllerV2 - $V2_PRISONER_GET_SOCIAL_CONTACTS_CONTROLLER_PATH")
+@DisplayName("PrisonerContactController - $V2_PRISONER_GET_SOCIAL_CONTACTS_CONTROLLER_PATH")
 class PrisonerGetSocialContactsTest : IntegrationTestBase() {
   val socialContactWithRestrictionId = 1L
   val socialContactWithExpiredRestrictionId = 2L

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/v2/PrisonerSearchContactsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/v2/PrisonerSearchContactsTest.kt
@@ -27,7 +27,7 @@ class PrisonerSearchContactsTest : IntegrationTestBase() {
     @Test
     fun `requires authentication`() {
       val prisonerId = "A1234AA"
-      webTestClient.get().uri("v2/prisoners/$prisonerId/contacts/search")
+      webTestClient.get().uri("/v2/prisoners/$prisonerId/contacts/search")
         .exchange()
         .expectStatus().isUnauthorized
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/v2/PrisonerSearchContactsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/v2/PrisonerSearchContactsTest.kt
@@ -1,0 +1,355 @@
+package uk.gov.justice.digital.hmpps.prisonercontactregistry.integration.v2
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.springframework.http.HttpStatus
+import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.controller.V2_PRISONER_SEARCH_CONTACTS
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.ContactWithOptionalPrisonerRelationshipDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PrisonerContactRestrictionsDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PrisonerContactRestrictionsResponseDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.integration.TestObjectMapper
+import java.time.LocalDate
+
+@Suppress("ClassName")
+@DisplayName("PrisonerContactController - $V2_PRISONER_SEARCH_CONTACTS")
+class PrisonerSearchContactsTest : IntegrationTestBase() {
+  @Nested
+  inner class authentication {
+    @Test
+    fun `requires authentication`() {
+      val prisonerId = "A1234AA"
+      webTestClient.get().uri("v2/prisoners/$prisonerId/contacts/search")
+        .exchange()
+        .expectStatus().isUnauthorized
+    }
+
+    @Test
+    fun `requires correct role`() {
+      val prisonerId = "A1234AA"
+      val contactIds = listOf(2187524L, 3147515L)
+
+      webTestClient.get()
+        .uri("/v2/prisoners/$prisonerId/contacts/search?contactIds=${contactIds.joinToString(",")}")
+        .headers(setAuthorisation(roles = listOf("AnyThingWillDo")))
+        .exchange()
+        .expectStatus().isForbidden
+        .expectBody()
+        .jsonPath("userMessage").isEqualTo("Access denied")
+    }
+  }
+
+  @Test
+  fun `search contacts returns contact with prisoner relationship and restrictions`() {
+    // Given
+    val prisonerId = "A1234AA"
+    val contactIds = listOf(2187524L)
+    val prisonerContactIds = listOf(999001L)
+
+    val contacts = createPersonalRelationshipsContactSearchResultDtoList(
+      contactIds = contactIds,
+      prisonerContactIds = prisonerContactIds,
+    )
+
+    val restrictionResponse = PrisonerContactRestrictionsResponseDto(
+      prisonerContactRestrictions = listOf(
+        PrisonerContactRestrictionsDto(
+          prisonerContactId = prisonerContactIds[0],
+          prisonerContactRestrictions = listOf(
+            createLocalRestriction(
+              prisonerContactRestrictionId = 123L,
+              prisonerContactId = prisonerContactIds[0],
+              contactId = contactIds[0],
+              prisonerNumber = prisonerId,
+              restrictionType = "CHILD",
+              restrictionTypeDescription = "Banned",
+              startDate = LocalDate.now().plusDays(5),
+              expiryDate = null,
+            ),
+          ),
+          globalContactRestrictions = emptyList(),
+        ),
+      ),
+    )
+
+    personalRelationshipsApiMockServer.stubSearchContacts(
+      prisonerId = prisonerId,
+      contactIds = contactIds,
+      contacts = contacts,
+    )
+
+    personalRelationshipsApiMockServer.stubPrisonerContactRestrictions(
+      prisonerContactIds = prisonerContactIds,
+      response = restrictionResponse,
+    )
+
+    // When
+    val result = callSearchContacts(
+      prisonerId = prisonerId,
+      contactIds = contactIds,
+      withRestrictions = true,
+    )
+
+    // Then
+    result.expectStatus().isOk
+
+    val responseList = getContactResults(result.expectBody())
+    assertThat(responseList).hasSize(1)
+    assertThat(responseList[0].contactId).isEqualTo(2187524)
+    assertThat(responseList[0].prisonerContactId).isEqualTo(999001L)
+    assertThat(responseList[0].restrictions).isNotEmpty()
+
+    verify(personalRelationshipsApiClientSpy, times(1)).searchContact(prisonerId, contactIds)
+    verify(personalRelationshipsApiClientSpy, times(1)).getPrisonerContactRestrictions(prisonerContactIds)
+    verify(personalRelationshipsApiClientSpy, never()).getContactGlobalRestrictions(any())
+    verifyNoMoreInteractions(personalRelationshipsApiClientSpy)
+  }
+
+  @Test
+  fun `search contacts returns contact with global restrictions only when no prisoner relationship exists`() {
+    // Given
+    val prisonerId = "A1234AA"
+    val contactIds = listOf(2187524L)
+    val prisonerContactIds = listOf<Long?>(null)
+
+    val contacts = createPersonalRelationshipsContactSearchResultDtoList(
+      contactIds = contactIds,
+      prisonerContactIds = prisonerContactIds,
+    )
+
+    val globalRestrictions = listOf(
+      createGlobalRestriction(
+        contactRestrictionId = 123L,
+        contactId = contactIds[0],
+        restrictionType = "CHILD",
+        restrictionTypeDescription = "Banned",
+        startDate = LocalDate.now().plusDays(5),
+        expiryDate = null,
+      ),
+    )
+
+    personalRelationshipsApiMockServer.stubSearchContacts(
+      prisonerId = prisonerId,
+      contactIds = contactIds,
+      contacts = contacts,
+    )
+
+    personalRelationshipsApiMockServer.stubGetContactGlobalRestrictions(
+      contactId = contactIds[0],
+      restrictions = globalRestrictions,
+    )
+
+    // When
+    val result = callSearchContacts(
+      prisonerId = prisonerId,
+      contactIds = contactIds,
+      withRestrictions = true,
+    )
+
+    // Then
+    result.expectStatus().isOk
+
+    val responseList = getContactResults(result.expectBody())
+    assertThat(responseList).hasSize(1)
+    assertThat(responseList[0].contactId).isEqualTo(2187524)
+    assertThat(responseList[0].prisonerContactId).isNull()
+    assertThat(responseList[0].restrictions).isNotEmpty()
+    assertThat(responseList[0].restrictions).hasSize(1)
+    assertThat(responseList[0].restrictions[0].restrictionType).isEqualTo("CHILD")
+    assertThat(responseList[0].restrictions[0].globalRestriction).isTrue()
+
+    verify(personalRelationshipsApiClientSpy, times(1)).searchContact(prisonerId, contactIds)
+    verify(personalRelationshipsApiClientSpy, never()).getPrisonerContactRestrictions(any())
+    verify(personalRelationshipsApiClientSpy, times(1)).getContactGlobalRestrictions(contactIds[0])
+    verifyNoMoreInteractions(personalRelationshipsApiClientSpy)
+  }
+
+  @Test
+  fun `search contacts returns relationship restrictions and global restrictions for mixed relationship results`() {
+    // Given
+    val prisonerId = "A1234AA"
+    val contactIds = listOf(2187524L, 2187525L)
+    val prisonerContactIds = listOf<Long?>(999001L, null)
+
+    val contacts = createPersonalRelationshipsContactSearchResultDtoList(
+      contactIds = contactIds,
+      prisonerContactIds = prisonerContactIds,
+    )
+
+    val prisonerContactRestrictionResponse = PrisonerContactRestrictionsResponseDto(
+      prisonerContactRestrictions = listOf(
+        PrisonerContactRestrictionsDto(
+          prisonerContactId = 999001L,
+          prisonerContactRestrictions = listOf(
+            createLocalRestriction(
+              prisonerContactRestrictionId = 123L,
+              prisonerContactId = 999001L,
+              contactId = 2187524L,
+              prisonerNumber = prisonerId,
+              restrictionType = "CHILD",
+              restrictionTypeDescription = "Banned",
+              startDate = LocalDate.now().plusDays(5),
+              expiryDate = null,
+            ),
+          ),
+          globalContactRestrictions = emptyList(),
+        ),
+      ),
+    )
+
+    val globalRestrictions = listOf(
+      createGlobalRestriction(
+        contactRestrictionId = 456L,
+        contactId = 2187525L,
+        restrictionType = "CLOSED",
+        restrictionTypeDescription = "Closed",
+        startDate = LocalDate.now().plusDays(10),
+        expiryDate = null,
+      ),
+    )
+
+    personalRelationshipsApiMockServer.stubSearchContacts(
+      prisonerId = prisonerId,
+      contactIds = contactIds,
+      contacts = contacts,
+    )
+
+    personalRelationshipsApiMockServer.stubPrisonerContactRestrictions(
+      prisonerContactIds = listOf(999001L),
+      response = prisonerContactRestrictionResponse,
+    )
+
+    personalRelationshipsApiMockServer.stubGetContactGlobalRestrictions(
+      contactId = 2187525L,
+      restrictions = globalRestrictions,
+    )
+
+    // When
+    val result = callSearchContacts(
+      prisonerId = prisonerId,
+      contactIds = contactIds,
+      withRestrictions = true,
+    )
+
+    // Then
+    result.expectStatus().isOk
+
+    val responseList = getContactResults(result.expectBody())
+    assertThat(responseList).hasSize(2)
+
+    val contactWithRelationship = responseList.first { it.contactId == 2187524L }
+    assertThat(contactWithRelationship.prisonerContactId).isEqualTo(999001L)
+    assertThat(contactWithRelationship.restrictions).hasSize(1)
+    assertThat(contactWithRelationship.restrictions[0].restrictionType).isEqualTo("CHILD")
+    assertThat(contactWithRelationship.restrictions[0].globalRestriction).isFalse()
+
+    val contactWithoutRelationship = responseList.first { it.contactId == 2187525L }
+    assertThat(contactWithoutRelationship.prisonerContactId).isNull()
+    assertThat(contactWithoutRelationship.restrictions).hasSize(1)
+    assertThat(contactWithoutRelationship.restrictions[0].restrictionType).isEqualTo("CLOSED")
+    assertThat(contactWithoutRelationship.restrictions[0].globalRestriction).isTrue()
+
+    verify(personalRelationshipsApiClientSpy, times(1)).searchContact(prisonerId, contactIds)
+    verify(personalRelationshipsApiClientSpy, times(1)).getPrisonerContactRestrictions(listOf(999001L))
+    verify(personalRelationshipsApiClientSpy, times(1)).getContactGlobalRestrictions(2187525L)
+    verifyNoMoreInteractions(personalRelationshipsApiClientSpy)
+  }
+
+  @Test
+  fun `search contacts returns contact with prisoner relationship but no restriction when withRestrictions is false`() {
+    // Given
+    val prisonerId = "A1234AA"
+    val contactIds = listOf(2187524L)
+    val prisonerContactIds = listOf(999001L)
+
+    val contacts = createPersonalRelationshipsContactSearchResultDtoList(
+      contactIds = contactIds,
+      prisonerContactIds = prisonerContactIds,
+    )
+
+    personalRelationshipsApiMockServer.stubSearchContacts(
+      prisonerId = prisonerId,
+      contactIds = contactIds,
+      contacts = contacts,
+    )
+
+    // When
+    val result = callSearchContacts(
+      prisonerId = prisonerId,
+      contactIds = contactIds,
+      withRestrictions = false,
+    )
+
+    // Then
+    result.expectStatus().isOk
+
+    val responseList = getContactResults(result.expectBody())
+    assertThat(responseList).hasSize(1)
+    assertThat(responseList[0].contactId).isEqualTo(2187524)
+    assertThat(responseList[0].prisonerContactId).isEqualTo(999001L)
+    assertThat(responseList[0].restrictions).isEmpty()
+
+    verify(personalRelationshipsApiClientSpy, times(1)).searchContact(prisonerId, contactIds)
+    verify(personalRelationshipsApiClientSpy, never()).getPrisonerContactRestrictions(any())
+    verify(personalRelationshipsApiClientSpy, never()).getContactGlobalRestrictions(any())
+    verifyNoMoreInteractions(personalRelationshipsApiClientSpy)
+  }
+
+  @Test
+  fun `search contacts returns bad request when personal relationships search returns bad request`() {
+    // Given
+    val prisonerId = "A1234AA"
+    val contactIds = listOf(2187524L)
+
+    personalRelationshipsApiMockServer.stubSearchContacts(
+      prisonerId = prisonerId,
+      contactIds = contactIds,
+      contacts = null,
+      httpStatus = HttpStatus.BAD_REQUEST,
+    )
+
+    // When
+    val result = callSearchContacts(
+      prisonerId = prisonerId,
+      contactIds = contactIds,
+    )
+
+    // Then
+    result.expectStatus().isBadRequest
+
+    verify(personalRelationshipsApiClientSpy, times(1)).searchContact(prisonerId, contactIds)
+    verify(personalRelationshipsApiClientSpy, never()).getPrisonerContactRestrictions(any())
+    verify(personalRelationshipsApiClientSpy, never()).getContactGlobalRestrictions(any())
+    verifyNoMoreInteractions(personalRelationshipsApiClientSpy)
+  }
+
+  private fun getContactResults(returnResult: WebTestClient.BodyContentSpec): Array<ContactWithOptionalPrisonerRelationshipDto> = TestObjectMapper.mapper.readValue(returnResult.returnResult().responseBody, Array<ContactWithOptionalPrisonerRelationshipDto>::class.java)
+
+  private fun callSearchContacts(
+    prisonerId: String,
+    contactIds: List<Long>,
+    withRestrictions: Boolean? = null,
+  ): WebTestClient.ResponseSpec {
+    val queryParams = mutableListOf<String>()
+
+    queryParams.add("contactIds=${contactIds.joinToString(",")}")
+
+    withRestrictions?.let { queryParams.add("withRestrictions=$it") }
+
+    val uri = "/v2/prisoners/$prisonerId/contacts/search?${queryParams.joinToString("&")}"
+
+    return webTestClient
+      .get()
+      .uri(uri)
+      .headers(setAuthorisation(roles = listOf("ROLE_PRISONER_CONTACT_REGISTRY")))
+      .exchange()
+  }
+}


### PR DESCRIPTION
## What does this PR do?

This new endpoint will call the searchContacts endpoint on the personal-relationships-api and transform to a DTO usable within the visits space.

With this endpoint it is possible to get back infromation of a contact with no prisoner relationship details. This is because the relationship might have been deleted and no longer exists, but we still want to give the basic contact information.

WIP - Tests to come.

## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-5817