### PR TITLE
Duplicate endpoint from PrisonerContactController to ContactsController

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/client/PersonalRelationshipsApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/client/PersonalRelationshipsApiClient.kt
@@ -165,21 +165,25 @@ class PersonalRelationshipsApiClient(
       .content
   }
 
-  fun searchContact(prisonerId: String, contactIds: List<Long>): List<PersonalRelationshipsContactSearchResultDto> {
-    logger.info("searchContact called for $prisonerId, with contactIds ${contactIds.joinToString { it.toString() }} via the personal-relationships-api")
+  fun searchContact(prisonerId: String? = null, contactIds: List<Long>): List<PersonalRelationshipsContactSearchResultDto> {
+    logger.info("searchContact called with contactIds ${contactIds.joinToString { it.toString() }} and prisonerId if provided = $prisonerId - via the personal-relationships-api")
 
     val uri = "/contact/search"
 
     return webClient.get()
       .uri { uriBuilder ->
-        uriBuilder
+        val builder = uriBuilder
           .path(uri)
-          .queryParam("includePrisonerRelationships", prisonerId)
           .queryParam("contactIds", contactIds.joinToString(","))
           .queryParam("searchType", "EXACT")
           .queryParam("page", 0)
           .queryParam("size", 400)
-          .build()
+
+        prisonerId?.let {
+          builder.queryParam("includePrisonerRelationships", it)
+        }
+
+        builder.build()
       }
       .retrieve()
       .bodyToMono(object : ParameterizedTypeReference<PagedResponse<PersonalRelationshipsContactSearchResultDto>>() {})

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/ContactsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/ContactsController.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.prisonercontactregistry.controller
 
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -12,17 +14,21 @@ import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.ContactDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.ContactWithOptionalPrisonerRelationshipDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.RestrictionDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.ContactLinkedPrisonerDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.service.ContactsService
 
-const val CONTACTS_CONTROLLER_PATH: String = "v2/contacts/{contactId}"
+const val CONTACTS_CONTROLLER_PATH: String = "v2/contacts"
+const val SINGLE_CONTACT_PATH: String = "$CONTACTS_CONTROLLER_PATH/{contactId}"
+const val GET_CONTACT_LINKED_PRISONERS_CONTROLLER_PATH: String = "$SINGLE_CONTACT_PATH/linked-social-prisoners"
+const val GET_CONTACT_GLOBAL_RESTRICTIONS_CONTROLLER_PATH: String = "$SINGLE_CONTACT_PATH/restrictions/global"
 
-const val GET_CONTACT_LINKED_PRISONERS_CONTROLLER_PATH: String = "$CONTACTS_CONTROLLER_PATH/linked-social-prisoners"
-const val GET_CONTACT_GLOBAL_RESTRICTIONS_CONTROLLER_PATH: String = "$CONTACTS_CONTROLLER_PATH/restrictions/global"
+const val CONTACT_SEARCH_PATH: String = "$CONTACTS_CONTROLLER_PATH/search"
 
 @RestController
 @Validated
@@ -35,7 +41,7 @@ class ContactsController(
   }
 
   @PreAuthorize("hasRole('PRISONER_CONTACT_REGISTRY')")
-  @GetMapping(CONTACTS_CONTROLLER_PATH)
+  @GetMapping(SINGLE_CONTACT_PATH, produces = [MediaType.APPLICATION_JSON_VALUE])
   @Operation(
     summary = "Get a contact via Contact ID",
     description = "Returns a contact's basic details",
@@ -74,6 +80,53 @@ class ContactsController(
     log.debug("getContact called with contactId: {}", contactId)
 
     return contactsService.getContactByContactId(contactId)
+  }
+
+  @PreAuthorize("hasRole('PRISONER_CONTACT_REGISTRY')")
+  @GetMapping(CONTACT_SEARCH_PATH)
+  @Operation(
+    summary = "Search for contacts with a potential relationship to a prisoner",
+    description = "Returns contact details (including relationship details of prisoner if prisonerId provided).",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Contact information returned, including relationship details of prisoner if prisonerId provided",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Incorrect request to search for contacts with a potential relationship to a prisoner",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Incorrect permissions to search for contacts with a potential relationship to a prisoner",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun searchContacts(
+    @RequestParam(required = true)
+    @Parameter(`in` = ParameterIn.QUERY, description = "Contact IDs. Comma-separated list of contact IDs, e.g. contactIds=123,456,789", example = "123,456,789", required = true)
+    contactIds: List<Long>,
+    @RequestParam(required = false)
+    @Parameter(`in` = ParameterIn.QUERY, description = "The unique identifier of the prisoner (e.g. prisonNumber, prisonerNumber, prisonId). If provided, relationship information will be included between contacts and prisoner", example = "AA123456", required = false)
+    prisonerId: String? = null,
+    @RequestParam(required = false)
+    @Parameter(description = "Defaults to false. Returns all contacts restrictions if set to true, skips grabbing restrictions if false", example = "false")
+    withRestrictions: Boolean? = false,
+  ): List<ContactWithOptionalPrisonerRelationshipDto> {
+    PrisonerContactController.Companion.log.debug("searchContacts called with params : Prisoner: {}, contactIds = {}, withRestrictions = {}", prisonerId, contactIds, withRestrictions)
+
+    return contactsService.searchContacts(
+      contactIds = contactIds,
+      prisonerId = prisonerId,
+      withRestrictions = withRestrictions ?: false,
+    )
   }
 
   @PreAuthorize("hasRole('PRISONER_CONTACT_REGISTRY')")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/ContactsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/ContactsController.kt
@@ -120,7 +120,7 @@ class ContactsController(
     @Parameter(description = "Defaults to false. Returns all contacts restrictions if set to true, skips grabbing restrictions if false", example = "false")
     withRestrictions: Boolean? = false,
   ): List<ContactWithOptionalPrisonerRelationshipDto> {
-    PrisonerContactController.Companion.log.debug("searchContacts called with params : Prisoner: {}, contactIds = {}, withRestrictions = {}", prisonerId, contactIds, withRestrictions)
+    log.debug("searchContacts called with params : Prisoner: {}, contactIds = {}, withRestrictions = {}", prisonerId, contactIds, withRestrictions)
 
     return contactsService.searchContacts(
       contactIds = contactIds,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/PrisonerContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/controller/PrisonerContactController.kt
@@ -99,6 +99,7 @@ class PrisonerContactController(private val contactService: PrisonerContactFacad
     )
   }
 
+  @Deprecated("Use v2/contacts/search instead.")
   @PreAuthorize("hasRole('PRISONER_CONTACT_REGISTRY')")
   @GetMapping(V2_PRISONER_SEARCH_CONTACTS)
   @Operation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/personal/relationships/PersonalRelationshipsContactSearchResultDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/personal/relationships/PersonalRelationshipsContactSearchResultDto.kt
@@ -156,7 +156,7 @@ fun PersonalRelationshipsContactSearchResultDto.toContactWithOptionalPrisonerRel
         relationshipDescription = null,
         contactType = null,
         contactTypeDescription = null,
-        restrictions = emptyList(),
+        restrictions = emptyList(), // Restrictions are handled after retrieval of contact information, hence setting to emptyList() here.
         address = address,
         approvedVisitor = null,
         emergencyContact = null,
@@ -177,7 +177,7 @@ fun PersonalRelationshipsContactSearchResultDto.toContactWithOptionalPrisonerRel
         relationshipDescription = relationship.relationshipToPrisonerDescription,
         contactType = relationship.relationshipTypeCode,
         contactTypeDescription = relationship.relationshipTypeDescription,
-        restrictions = emptyList(),
+        restrictions = emptyList(), // Restrictions are handled after retrieval of contact information, hence setting to emptyList() here.
         address = address,
         approvedVisitor = relationship.isApprovedVisitor,
         emergencyContact = relationship.isEmergencyContact,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/service/ContactsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/service/ContactsService.kt
@@ -5,8 +5,10 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.client.PersonalRelationshipsApiClient
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.ContactDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.ContactWithOptionalPrisonerRelationshipDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.RestrictionDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.ContactLinkedPrisonerDto
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.toContactWithOptionalPrisonerRelationshipDto
 
 @Service
 class ContactsService(
@@ -21,6 +23,54 @@ class ContactsService(
   fun getContactByContactId(contactId: Long): ContactDto {
     log.debug("getContactByContactId called with parameters : contactId - {}", contactId)
     return personalRelationshipsApiClient.getContact(contactId)
+  }
+
+  fun searchContacts(contactIds: List<Long>, prisonerId: String? = null, withRestrictions: Boolean): List<ContactWithOptionalPrisonerRelationshipDto> {
+    log.debug(
+      "searchContacts called with parameters : prisonerId - {}, contactIds - {}, withRestrictions - {}",
+      prisonerId,
+      contactIds,
+      withRestrictions,
+    )
+
+    val foundContacts = personalRelationshipsApiClient.searchContact(prisonerId, contactIds)
+
+    val contacts = foundContacts.flatMap { contact ->
+      contact.toContactWithOptionalPrisonerRelationshipDto().filter { it.contactType != "O" }
+    }
+
+    if (!withRestrictions) {
+      return contacts
+    }
+
+    val indexedGlobalAndLocalRestrictions = restrictionsService.getContactsGlobalAndLocalRestrictions(
+      contacts
+        .mapNotNull { it.prisonerContactId }
+        .distinct(),
+    )
+
+    // Because local restrictions are bound between prisoner and contact, if relationship is null we need to do a separate
+    // global restrictions lookup for these contacts.
+    val globalRestrictionsByContactId = contacts
+      .filter { it.prisonerContactId == null }
+      .map { it.contactId }
+      .distinct()
+      .associateWith { contactId ->
+        restrictionsService.getContactGlobalRestrictions(contactId)
+      }
+
+    return contacts.map { contact ->
+      val restrictions = if (contact.prisonerContactId != null) {
+        indexedGlobalAndLocalRestrictions.forContact(
+          contactId = contact.contactId,
+          prisonerContactId = contact.prisonerContactId,
+        )
+      } else {
+        globalRestrictionsByContactId[contact.contactId].orEmpty()
+      }
+
+      contact.copy(restrictions = restrictions)
+    }
   }
 
   fun getContactLinkedPrisonersByContactId(contactId: Long): List<ContactLinkedPrisonerDto> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/service/PrisonerContactFacadeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/service/PrisonerContactFacadeService.kt
@@ -23,6 +23,7 @@ class PrisonerContactFacadeService(
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
+  // Remove
   fun searchContacts(prisonerId: String, contactIds: List<Long>, withRestrictions: Boolean): List<ContactWithOptionalPrisonerRelationshipDto> {
     log.debug(
       "searchContacts called with parameters : prisonerId - {}, contactIds - {}, withRestrictions - {}",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/service/PrisonerContactFacadeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/service/PrisonerContactFacadeService.kt
@@ -23,7 +23,6 @@ class PrisonerContactFacadeService(
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  // Remove
   fun searchContacts(prisonerId: String, contactIds: List<Long>, withRestrictions: Boolean): List<ContactWithOptionalPrisonerRelationshipDto> {
     log.debug(
       "searchContacts called with parameters : prisonerId - {}, contactIds - {}, withRestrictions - {}",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/contact/GetContactTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/contact/GetContactTest.kt
@@ -8,13 +8,13 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.springframework.http.HttpStatus
 import org.springframework.test.web.reactive.server.WebTestClient
-import uk.gov.justice.digital.hmpps.prisonercontactregistry.controller.CONTACTS_CONTROLLER_PATH
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.controller.SINGLE_CONTACT_PATH
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.ContactDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.integration.TestObjectMapper
 
 @Suppress("ClassName")
-@DisplayName("ContactsController - Get Contact - $CONTACTS_CONTROLLER_PATH")
+@DisplayName("ContactsController - Get Contact - $SINGLE_CONTACT_PATH")
 class GetContactTest : IntegrationTestBase() {
   @Nested
   inner class authentication {
@@ -22,7 +22,7 @@ class GetContactTest : IntegrationTestBase() {
     fun `requires authentication`() {
       val contactId = 2187525L
 
-      webTestClient.get().uri(CONTACTS_CONTROLLER_PATH.replace("{contactId}", contactId.toString()))
+      webTestClient.get().uri(SINGLE_CONTACT_PATH.replace("{contactId}", contactId.toString()))
         .exchange()
         .expectStatus().isUnauthorized
     }
@@ -31,7 +31,7 @@ class GetContactTest : IntegrationTestBase() {
     fun `requires correct role`() {
       val contactId = 2187525L
 
-      webTestClient.get().uri(CONTACTS_CONTROLLER_PATH.replace("{contactId}", contactId.toString()))
+      webTestClient.get().uri(SINGLE_CONTACT_PATH.replace("{contactId}", contactId.toString()))
         .headers(setAuthorisation(roles = listOf("AnyThingWillDo")))
         .exchange()
         .expectStatus().isForbidden
@@ -83,7 +83,7 @@ class GetContactTest : IntegrationTestBase() {
   private fun callGetContact(
     contactId: Long,
   ): WebTestClient.ResponseSpec {
-    val uri = CONTACTS_CONTROLLER_PATH.replace("{contactId}", contactId.toString())
+    val uri = SINGLE_CONTACT_PATH.replace("{contactId}", contactId.toString())
     return webTestClient
       .get()
       .uri(uri)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/contact/SearchContactsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/contact/SearchContactsTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.prisonercontactregistry.integration.v2
+package uk.gov.justice.digital.hmpps.prisonercontactregistry.integration.contact
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
@@ -11,7 +11,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.springframework.http.HttpStatus
 import org.springframework.test.web.reactive.server.WebTestClient
-import uk.gov.justice.digital.hmpps.prisonercontactregistry.controller.V2_PRISONER_SEARCH_CONTACTS
+import uk.gov.justice.digital.hmpps.prisonercontactregistry.controller.CONTACT_SEARCH_PATH
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.ContactWithOptionalPrisonerRelationshipDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PrisonerContactRestrictionsDto
 import uk.gov.justice.digital.hmpps.prisonercontactregistry.dto.personal.relationships.PrisonerContactRestrictionsResponseDto
@@ -20,14 +20,14 @@ import uk.gov.justice.digital.hmpps.prisonercontactregistry.integration.TestObje
 import java.time.LocalDate
 
 @Suppress("ClassName")
-@DisplayName("PrisonerContactController - $V2_PRISONER_SEARCH_CONTACTS")
-class PrisonerSearchContactsTest : IntegrationTestBase() {
+@DisplayName("ContactController - $CONTACT_SEARCH_PATH")
+class SearchContactsTest : IntegrationTestBase() {
   @Nested
   inner class authentication {
     @Test
     fun `requires authentication`() {
       val prisonerId = "A1234AA"
-      webTestClient.get().uri("/v2/prisoners/$prisonerId/contacts/search")
+      webTestClient.get().uri("/v2/contacts/search")
         .exchange()
         .expectStatus().isUnauthorized
     }
@@ -38,7 +38,7 @@ class PrisonerSearchContactsTest : IntegrationTestBase() {
       val contactIds = listOf(2187524L, 3147515L)
 
       webTestClient.get()
-        .uri("/v2/prisoners/$prisonerId/contacts/search?contactIds=${contactIds.joinToString(",")}")
+        .uri("/v2/contacts/search?contactIds=${contactIds.joinToString(",")}")
         .headers(setAuthorisation(roles = listOf("AnyThingWillDo")))
         .exchange()
         .expectStatus().isForbidden
@@ -138,7 +138,7 @@ class PrisonerSearchContactsTest : IntegrationTestBase() {
 
     personalRelationshipsApiMockServer.stubSearchContacts(
       contactIds = contactIds,
-      prisonerId = prisonerId,
+      prisonerId = null,
       contacts = contacts,
     )
 
@@ -149,8 +149,8 @@ class PrisonerSearchContactsTest : IntegrationTestBase() {
 
     // When
     val result = callSearchContacts(
-      prisonerId = prisonerId,
       contactIds = contactIds,
+      prisonerId = null,
       withRestrictions = true,
     )
 
@@ -166,7 +166,7 @@ class PrisonerSearchContactsTest : IntegrationTestBase() {
     assertThat(responseList[0].restrictions[0].restrictionType).isEqualTo("CHILD")
     assertThat(responseList[0].restrictions[0].globalRestriction).isTrue()
 
-    verify(personalRelationshipsApiClientSpy, times(1)).searchContact(prisonerId, contactIds)
+    verify(personalRelationshipsApiClientSpy, times(1)).searchContact(null, contactIds)
     verify(personalRelationshipsApiClientSpy, never()).getPrisonerContactRestrictions(any())
     verify(personalRelationshipsApiClientSpy, times(1)).getContactGlobalRestrictions(contactIds[0])
     verifyNoMoreInteractions(personalRelationshipsApiClientSpy)
@@ -234,8 +234,8 @@ class PrisonerSearchContactsTest : IntegrationTestBase() {
 
     // When
     val result = callSearchContacts(
-      prisonerId = prisonerId,
       contactIds = contactIds,
+      prisonerId = prisonerId,
       withRestrictions = true,
     )
 
@@ -283,8 +283,8 @@ class PrisonerSearchContactsTest : IntegrationTestBase() {
 
     // When
     val result = callSearchContacts(
-      prisonerId = prisonerId,
       contactIds = contactIds,
+      prisonerId = prisonerId,
       withRestrictions = false,
     )
 
@@ -318,8 +318,8 @@ class PrisonerSearchContactsTest : IntegrationTestBase() {
 
     // When
     val result = callSearchContacts(
-      prisonerId = prisonerId,
       contactIds = contactIds,
+      prisonerId = prisonerId,
     )
 
     // Then
@@ -334,17 +334,17 @@ class PrisonerSearchContactsTest : IntegrationTestBase() {
   private fun getContactResults(returnResult: WebTestClient.BodyContentSpec): Array<ContactWithOptionalPrisonerRelationshipDto> = TestObjectMapper.mapper.readValue(returnResult.returnResult().responseBody, Array<ContactWithOptionalPrisonerRelationshipDto>::class.java)
 
   private fun callSearchContacts(
-    prisonerId: String,
     contactIds: List<Long>,
+    prisonerId: String? = null,
     withRestrictions: Boolean? = null,
   ): WebTestClient.ResponseSpec {
     val queryParams = mutableListOf<String>()
 
     queryParams.add("contactIds=${contactIds.joinToString(",")}")
-
+    prisonerId?.let { queryParams.add("prisonerId=$it") }
     withRestrictions?.let { queryParams.add("withRestrictions=$it") }
 
-    val uri = "/v2/prisoners/$prisonerId/contacts/search?${queryParams.joinToString("&")}"
+    val uri = "/v2/contacts/search?${queryParams.joinToString("&")}"
 
     return webTestClient
       .get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/contact/SearchContactsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/contact/SearchContactsTest.kt
@@ -26,7 +26,6 @@ class SearchContactsTest : IntegrationTestBase() {
   inner class authentication {
     @Test
     fun `requires authentication`() {
-      val prisonerId = "A1234AA"
       webTestClient.get().uri("/v2/contacts/search")
         .exchange()
         .expectStatus().isUnauthorized
@@ -34,7 +33,6 @@ class SearchContactsTest : IntegrationTestBase() {
 
     @Test
     fun `requires correct role`() {
-      val prisonerId = "A1234AA"
       val contactIds = listOf(2187524L, 3147515L)
 
       webTestClient.get()
@@ -116,7 +114,6 @@ class SearchContactsTest : IntegrationTestBase() {
   @Test
   fun `search contacts returns contact with global restrictions only when no prisoner relationship exists`() {
     // Given
-    val prisonerId = "A1234AA"
     val contactIds = listOf(2187524L)
     val prisonerContactIds = listOf<Long?>(null)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/mock/PersonalRelationshipsApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/mock/PersonalRelationshipsApiMockServer.kt
@@ -45,8 +45,8 @@ class PersonalRelationshipsApiMockServer : WireMockServer(8093) {
   }
 
   fun stubSearchContacts(
-    prisonerId: String,
     contactIds: List<Long>,
+    prisonerId: String? = null,
     contacts: List<PersonalRelationshipsContactSearchResultDto>? = null,
     page: Int = 0,
     size: Int = 400,
@@ -78,15 +78,17 @@ class PersonalRelationshipsApiMockServer : WireMockServer(8093) {
         )
     }
 
-    stubFor(
-      get(urlPathEqualTo(uri))
-        .withQueryParam("includePrisonerRelationships", equalTo(prisonerId))
-        .withQueryParam("contactIds", equalTo(contactIds.joinToString(",")))
-        .withQueryParam("searchType", equalTo("EXACT"))
-        .withQueryParam("page", equalTo(page.toString()))
-        .withQueryParam("size", equalTo(size.toString()))
-        .willReturn(response),
-    )
+    val request = get(urlPathEqualTo(uri))
+      .withQueryParam("contactIds", equalTo(contactIds.joinToString(",")))
+      .withQueryParam("searchType", equalTo("EXACT"))
+      .withQueryParam("page", equalTo(page.toString()))
+      .withQueryParam("size", equalTo(size.toString()))
+
+    prisonerId?.let {
+      request.withQueryParam("includePrisonerRelationships", equalTo(it))
+    }
+
+    stubFor(request.willReturn(response))
   }
 
   fun stubGetAllContacts(
@@ -161,7 +163,6 @@ class PersonalRelationshipsApiMockServer : WireMockServer(8093) {
     stubFor(
       post(urlPathEqualTo(uri))
         .withHeader(HttpHeaders.CONTENT_TYPE, containing(MediaType.APPLICATION_JSON_VALUE))
-        // ignoreArrayOrder = true, ignoreExtraElements = true
         .withRequestBody(equalToJson(expectedRequestJson, true, true))
         .willReturn(wiremockResponse),
     )


### PR DESCRIPTION
## What does this pull request do?

Due to a change in requirements, we need the prisonerId to be an optional request parameter, not a required URL path variable.

This is because sometimes we want to retrieve contact infromation without the link to the prisoner. This is rare but allows us to do it without needing multiple endpoints.

original endpoint in PrisonerContactController marked for removal. Once all upstream APIs have swapped to this new endpoint, it will be removed.