### PR TITLE
VB-6353 add relationship id to prisoner contact

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ Then view output file for coverage report.
 
 This service connects to a development environment for downstream APIs. 
 
+First, copy the [example.env file](./example.env) at the project root and [add 2 secrets to it](.env).
+```bash
+cp example.env .env
+```
+
 Create a Spring Boot run configuration with active profile of 'dev', to run against te development environment.
 
 Ports

--- a/example.env
+++ b/example.env
@@ -1,0 +1,2 @@
+SYSTEM_CLIENT_ID='get from kubernetes secrets for dev namespace'
+SYSTEM_CLIENT_SECRET='get from kubernetes secrets for dev namespace'

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/PrisonerContactDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/PrisonerContactDto.kt
@@ -15,6 +15,8 @@ data class PrisonerContactDto(
   val lastName: String,
   @param:Schema(description = "Date of birth", example = "1980-01-28", required = false)
   val dateOfBirth: LocalDate? = null,
+  @param:Schema(description = "Key of specific relationship", example = "1234567", required = true)
+  val relationshipId: Long,
   @param:Schema(description = "Code for relationship to Prisoner", example = "RO", required = true)
   val relationshipCode: String,
   @param:Schema(description = "Description of relationship to Prisoner", example = "Responsible Officer", required = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/personal/relationships/PersonalRelationshipsPrisonerContactDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/dto/personal/relationships/PersonalRelationshipsPrisonerContactDto.kt
@@ -87,6 +87,7 @@ data class PersonalRelationshipsPrisonerContactDto(
     middleName = middleNames.toNormalCase(),
     lastName = lastName.toNormalCase().orEmpty(),
     dateOfBirth = dateOfBirth,
+    relationshipId = prisonerContactId,
     relationshipCode = relationshipToPrisonerCode,
     relationshipDescription = relationshipToPrisonerDescription,
     contactType = relationshipTypeCode,


### PR DESCRIPTION
## What does this pull request do?

Updates the prisonerContactDto to include relationship ID, so we can build a URL to the booker page

## What is the intent behind these changes?

To improve visibility for prison staff when matching visitor records