### PR TITLE
Increase contact return limit to 450

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/client/PersonalRelationshipsApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/client/PersonalRelationshipsApiClient.kt
@@ -164,7 +164,7 @@ class PersonalRelationshipsApiClient(
           .path(uri)
           .queryParam("relationshipType", "S")
           .queryParam("page", 0)
-          .queryParam("size", 400)
+          .queryParam("size", 450)
           .apply {
             // Only set this param if it's true. Setting it to false returns only unapproved visitors (we do not want this).
             if (approvedVisitorOnly) {
@@ -200,7 +200,7 @@ class PersonalRelationshipsApiClient(
           .queryParam("contactIds", contactIds.joinToString(","))
           .queryParam("searchType", "EXACT")
           .queryParam("page", 0)
-          .queryParam("size", 400)
+          .queryParam("size", 450)
 
         prisonerId?.let {
           builder.queryParam("includePrisonerRelationships", it)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/mock/PersonalRelationshipsApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonercontactregistry/integration/mock/PersonalRelationshipsApiMockServer.kt
@@ -52,7 +52,7 @@ class PersonalRelationshipsApiMockServer : WireMockServer(8093) {
     prisonerId: String? = null,
     contacts: List<PersonalRelationshipsContactSearchResultDto>? = null,
     page: Int = 0,
-    size: Int = 400,
+    size: Int = 450,
     httpStatus: HttpStatus = HttpStatus.OK,
   ) {
     val uri = "/contact/search"
@@ -99,7 +99,7 @@ class PersonalRelationshipsApiMockServer : WireMockServer(8093) {
     contacts: List<PersonalRelationshipsPrisonerContactDto>? = null,
     approvedVisitorOnly: Boolean = false,
     page: Int = 0,
-    size: Int = 400,
+    size: Int = 450,
     httpStatus: HttpStatus = HttpStatus.OK,
   ) {
     val uri = "/prisoner/$prisonerId/contact"


### PR DESCRIPTION
## What does this pull request do?

Increases contact return limit to 450.

## What is the intent behind these changes?

Allows prisoners with large number of contacts to be viewed - if limit is hit, the prisoner cannot have any visits booked or updated.